### PR TITLE
ci: lower max-generations from 5 to 3

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=10000 --convergence-threshold=0.01 --max-generations=5 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=10000 --convergence-threshold=0.01 --max-generations=3 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
At ~100 min/generation on CI runners, 3 generations fits within the 6-hour GHA limit while 5 would risk timeout.

The currently running production job (Run #9) still uses `--max-generations=5`, but should converge well before hitting 5 given the strong analytical bootstrap.