### PR TITLE
ci: print convergence shift in table generation

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=8000 --convergence-threshold=0.01 --max-generations=3 --output=expected_crib_points.json --no-resume --seed=42
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=8000 --convergence-threshold=0.01 --max-generations=3 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=8000 --convergence-threshold=0.01 --max-generations=3 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=8000 --convergence-threshold=0.01 --max-generations=3 --output=expected_crib_points.json --no-resume --seed=42
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -827,6 +827,10 @@ def main(override_pairs=None):
                         pairs,
                         measured_accumulators=accumulators,
                     )
+                    print(
+                        f"Generation {generation} convergence check: "
+                        f"max EV shift = {max_shift:.6f} (threshold = {args.convergence_threshold})"
+                    )
                     if max_shift <= args.convergence_threshold:
                         print(
                             f"Converged at generation {generation} with max EV shift {max_shift} <= {args.convergence_threshold}"


### PR DESCRIPTION
Add a print statement to `generate_table.py` showing the actual `max EV shift` when performing the convergence check at the end of each generation, making it visible in the runner outputs.

This helps monitor convergence progress during Monte Carlo runs.