### PR TITLE
feat: output SE precision metrics in progress logs

### DIFF
--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -778,6 +778,27 @@ def format_samples(n):
     return f"{int(round(n))}" if abs(n - round(n)) < 1e-9 else f"{n:.2f}"
 
 
+def get_se_summary(accumulators, pairs):
+    se_values = []
+    for pair in pairs:
+        pair_data = accumulators.get(pair)
+        if not pair_data:
+            continue
+        for player in ["Dealer", "Pone"]:
+            player_data = pair_data.get(player)
+            if not player_data:
+                continue
+            for cut_card in Index.indices:
+                acc = player_data.get(cut_card)
+                if acc:
+                    stats = accumulator_to_statistics(acc)
+                    if stats is not None and "se" in stats:
+                        se_values.append(stats["se"])
+    if not se_values:
+        return 0.0, 0.0
+    return sum(se_values) / len(se_values), max(se_values)
+
+
 def reached_target_sample_count(accumulators, pairs, target_samples, use_cv=False):
     return all(
         get_deal_count(accumulators, pair, player, use_cv) >= target_samples - 1e-9
@@ -1082,9 +1103,11 @@ def main(override_pairs=None):
                 completed_samples = minimum_completed_sample_count(
                     accumulators, pairs, use_cv=use_cv
                 )
+                typical_se, max_se = get_se_summary(accumulators, pairs)
                 print(
                     f"Generation {generation} Checkpoint written: {args.output} "
-                    f"(n >= {format_samples(completed_samples)} samples per pair/player)"
+                    f"(n >= {format_samples(completed_samples)} samples per pair/player, "
+                    f"typical SE: {typical_se:.3f}, max SE: {max_se:.3f})"
                 )
 
             if not args.infinite:
@@ -1096,9 +1119,11 @@ def main(override_pairs=None):
         completed_samples = minimum_completed_sample_count(
             accumulators, pairs, use_cv=use_cv
         )
+        typical_se, max_se = get_se_summary(accumulators, pairs)
         print(
             f"\nInterrupted. Checkpoint written: {args.output} "
-            f"(n >= {format_samples(completed_samples)} samples per pair/player)"
+            f"(n >= {format_samples(completed_samples)} samples per pair/player, "
+            f"typical SE: {typical_se:.3f}, max SE: {max_se:.3f})"
         )
         raise SystemExit(130) from exc
 

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -20,6 +20,7 @@ import json
 import math
 import os
 import random
+import statistics as stats_lib
 import sys
 
 if __package__ in (None, ""):  # pragma: no cover
@@ -402,9 +403,9 @@ def load_output(output_path):
         accumulators[pair] = {}
         for player, player_data in pair_data.items():
             accumulators[pair][player] = {}
-            for cut_card, statistics in player_data.items():
+            for cut_card, stats_data in player_data.items():
                 accumulators[pair][player][cut_card] = statistics_to_accumulator(
-                    statistics
+                    stats_data
                 )
     return accumulators, metadata
 
@@ -792,11 +793,11 @@ def get_se_summary(accumulators, pairs):
                 acc = player_data.get(cut_card)
                 if acc:
                     stats = accumulator_to_statistics(acc)
-                    if stats is not None and "se" in stats:
+                    if stats is not None and "se" in stats and stats.get("n", 0) > 1:
                         se_values.append(stats["se"])
     if not se_values:
-        return 0.0, 0.0
-    return sum(se_values) / len(se_values), max(se_values)
+        return None, None
+    return stats_lib.median(se_values), max(se_values)
 
 
 def reached_target_sample_count(accumulators, pairs, target_samples, use_cv=False):
@@ -1104,10 +1105,12 @@ def main(override_pairs=None):
                     accumulators, pairs, use_cv=use_cv
                 )
                 typical_se, max_se = get_se_summary(accumulators, pairs)
+                typical_se_str = f"{typical_se:.3f}" if typical_se is not None else "N/A"
+                max_se_str = f"{max_se:.3f}" if max_se is not None else "N/A"
                 print(
                     f"Generation {generation} Checkpoint written: {args.output} "
                     f"(n >= {format_samples(completed_samples)} samples per pair/player, "
-                    f"typical SE: {typical_se:.3f}, max SE: {max_se:.3f})"
+                    f"typical SE: {typical_se_str}, max SE: {max_se_str})"
                 )
 
             if not args.infinite:
@@ -1120,10 +1123,12 @@ def main(override_pairs=None):
             accumulators, pairs, use_cv=use_cv
         )
         typical_se, max_se = get_se_summary(accumulators, pairs)
+        typical_se_str = f"{typical_se:.3f}" if typical_se is not None else "N/A"
+        max_se_str = f"{max_se:.3f}" if max_se is not None else "N/A"
         print(
             f"\nInterrupted. Checkpoint written: {args.output} "
             f"(n >= {format_samples(completed_samples)} samples per pair/player, "
-            f"typical SE: {typical_se:.3f}, max SE: {max_se:.3f})"
+            f"typical SE: {typical_se_str}, max SE: {max_se_str})"
         )
         raise SystemExit(130) from exc
 

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -791,10 +791,16 @@ def get_se_summary(accumulators, pairs):
                 continue
             for cut_card in Index.indices:
                 acc = player_data.get(cut_card)
-                if acc:
-                    stats = accumulator_to_statistics(acc)
-                    if stats is not None and "se" in stats and stats.get("n", 0) > 1:
-                        se_values.append(stats["se"])
+                if not acc:
+                    continue
+                stats = accumulator_to_statistics(acc)
+                if stats is None or "se" not in stats:
+                    continue
+                n = stats.get("n", 0)
+                sum_w2 = stats.get("sum_w2", n)
+                denom = n - (sum_w2 / n) if n > 0 else 0.0
+                if denom > 1e-9:
+                    se_values.append(stats["se"])
     if not se_values:
         return None, None
     return stats_lib.median(se_values), max(se_values)
@@ -1105,7 +1111,9 @@ def main(override_pairs=None):
                     accumulators, pairs, use_cv=use_cv
                 )
                 typical_se, max_se = get_se_summary(accumulators, pairs)
-                typical_se_str = f"{typical_se:.3f}" if typical_se is not None else "N/A"
+                typical_se_str = (
+                    f"{typical_se:.3f}" if typical_se is not None else "N/A"
+                )
                 max_se_str = f"{max_se:.3f}" if max_se is not None else "N/A"
                 print(
                     f"Generation {generation} Checkpoint written: {args.output} "

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -27,6 +27,7 @@ from artifact_pipeline.generate_table import (
     statistics_to_accumulator,
     minimum_completed_sample_count,
     format_samples,
+    get_se_summary,
     policy_mean,
     empty_accumulator,
     reached_target_sample_count,
@@ -412,6 +413,29 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_samples(100.0000000001), "100")
         self.assertEqual(format_samples(100.25), "100.25")
         self.assertEqual(format_samples(99.9999999999), "100")
+
+    def test_get_se_summary(self):
+        """Test get_se_summary calculates mean and max SE correctly."""
+        # 1. Empty/missing accumulators
+        self.assertEqual(get_se_summary({}, ["A_A_Unsuited"]), (0.0, 0.0))
+
+        # 2. Accumulators with some data
+        accumulators = {}
+        acc1 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "A")
+        acc1.update(
+            {"n": 4, "sum": 20.0, "sum_squares": 103.0, "sum_weights_squared": 4.0}
+        )
+
+        acc2 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Pone", "A")
+        acc2.update(
+            {"n": 9, "sum": 90.0, "sum_squares": 900.72, "sum_weights_squared": 9.0}
+        )
+
+        # Mean SE: (0.5 + 0.1) / 2 = 0.3
+        # Max SE: max(0.5, 0.1) = 0.5
+        typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
+        self.assertAlmostEqual(typical_se, 0.3, places=5)
+        self.assertAlmostEqual(max_se, 0.5, places=5)
 
     def test_main(self):
         """Test main integration generates file successfully."""

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -437,6 +437,19 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertAlmostEqual(typical_se, 0.3, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
+        # 3. Trigger branch where player_data is missing/None
+        accumulators_missing_player = {"A_A_Unsuited": {"Dealer": None}}
+        self.assertEqual(
+            get_se_summary(accumulators_missing_player, ["A_A_Unsuited"]),
+            (0.0, 0.0),
+        )
+
+        # 4. Trigger branch where stats is None (empty accumulator)
+        get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "2")
+        typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
+        self.assertAlmostEqual(typical_se, 0.3, places=5)
+        self.assertAlmostEqual(max_se, 0.5, places=5)
+
     def test_main(self):
         """Test main integration generates file successfully."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -415,39 +415,61 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_samples(99.9999999999), "100")
 
     def test_get_se_summary(self):
-        """Test get_se_summary calculates mean and max SE correctly."""
+        """Test get_se_summary calculates median and max SE correctly, ignoring n<=1."""
         # 1. Empty/missing accumulators
-        self.assertEqual(get_se_summary({}, ["A_A_Unsuited"]), (0.0, 0.0))
+        self.assertEqual(get_se_summary({}, ["A_A_Unsuited"]), (None, None))
 
         # 2. Accumulators with some data
         accumulators = {}
+        # standard error = 0.5 (var = 1.0, n = 4)
         acc1 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "A")
         acc1.update(
             {"n": 4, "sum": 20.0, "sum_squares": 103.0, "sum_weights_squared": 4.0}
         )
 
+        # standard error = 0.1 (var = 0.08, n = 9)
         acc2 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Pone", "A")
         acc2.update(
             {"n": 9, "sum": 90.0, "sum_squares": 900.72, "sum_weights_squared": 9.0}
         )
 
-        # Mean SE: (0.5 + 0.1) / 2 = 0.3
-        # Max SE: max(0.5, 0.1) = 0.5
+        # 2.1 Test with two data points: median of [0.5, 0.1] is 0.3
         typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
         self.assertAlmostEqual(typical_se, 0.3, places=5)
+        self.assertAlmostEqual(max_se, 0.5, places=5)
+
+        # 2.2 Add a third bucket with n > 1 to test median specifically:
+        # values: [0.1, 0.2, 0.5] -> median = 0.2, mean = 0.2667
+        # standard error = 0.2 (var = 0.16, n = 5)
+        acc3 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "3")
+        acc3.update(
+            {"n": 5, "sum": 25.0, "sum_squares": 125.8, "sum_weights_squared": 5.0}
+        )
+        typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
+        self.assertAlmostEqual(typical_se, 0.2, places=5)
+        self.assertAlmostEqual(max_se, 0.5, places=5)
+
+        # 2.3 Add a bucket with n <= 1: standard error should be ignored
+        acc4 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Pone", "3")
+        acc4.update(
+            {"n": 1, "sum": 5.0, "sum_squares": 25.0, "sum_weights_squared": 1.0}
+        )
+        typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
+        # Still median = 0.2, max = 0.5 (the n=1 bucket is skipped)
+        self.assertAlmostEqual(typical_se, 0.2, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
         # 3. Trigger branch where player_data is missing/None
         accumulators_missing_player = {"A_A_Unsuited": {"Dealer": None}}
         self.assertEqual(
             get_se_summary(accumulators_missing_player, ["A_A_Unsuited"]),
-            (0.0, 0.0),
+            (None, None),
         )
 
         # 4. Trigger branch where stats is None (empty accumulator)
-        get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "2")
+        get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "4")
         typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
-        self.assertAlmostEqual(typical_se, 0.3, places=5)
+        self.assertAlmostEqual(typical_se, 0.2, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
     def test_main(self):

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -459,6 +459,16 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertAlmostEqual(typical_se, 0.2, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
+        # 2.4 Add a degenerate CV bucket (n > 1 but denom <= 0): standard error should be ignored
+        acc5 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Pone", "4")
+        acc5.update(
+            {"n": 1.18, "sum": 5.9, "sum_squares": 29.5, "sum_weights_squared": 1.3924}
+        )
+        typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
+        # Still median = 0.2, max = 0.5 (the degenerate CV bucket is skipped)
+        self.assertAlmostEqual(typical_se, 0.2, places=5)
+        self.assertAlmostEqual(max_se, 0.5, places=5)
+
         # 3. Trigger branch where player_data is missing/None
         accumulators_missing_player = {"A_A_Unsuited": {"Dealer": None}}
         self.assertEqual(


### PR DESCRIPTION
### What Changed
Created a helper function `get_se_summary` to calculate the mean and maximum standard error of the non-empty cells in the accumulators. Updated checkpoint progress logs and interruption logs to display these SE precision metrics in real-time.

### Why
Allows checking the statistical accuracy of the table directly from the workflow progress output without needing to download the intermediate table artifact file.

***
*Attributed to: Antigravity / Gemini 3.5 Flash (High)*