### PR TITLE
perf: optimize expected crib table generation

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   generate-table:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     permissions:
       contents: read
 

--- a/artifact_pipeline/adapter.py
+++ b/artifact_pipeline/adapter.py
@@ -28,6 +28,7 @@ __all__ = [
     "BEST_STATIC_SELECT_PONE_KEPT_CARDS",
     "BEST_STATIC_SELECT_DEALER_KEPT_CARDS",
     "get_canonical_pairs",
+    "score_hand_over_starters",
 ]
 
 
@@ -55,3 +56,60 @@ def get_canonical_pairs():
                 pairs.append(f"{rank1}_{rank2}_Unsuited")
 
     return pairs
+
+
+JACK_INDEX = 10
+
+
+def insert_sorted(sorted_4, x):
+    """
+    Inserts value x into a sorted 4-element tuple to produce a sorted 5-element tuple.
+    Avoids overhead of sorting list of 5 elements.
+    """
+    if x <= sorted_4[0]:
+        return (x, sorted_4[0], sorted_4[1], sorted_4[2], sorted_4[3])
+    if x <= sorted_4[1]:
+        return (sorted_4[0], x, sorted_4[1], sorted_4[2], sorted_4[3])
+    if x <= sorted_4[2]:
+        return (sorted_4[0], sorted_4[1], x, sorted_4[2], sorted_4[3])
+    if x <= sorted_4[3]:
+        return (sorted_4[0], sorted_4[1], sorted_4[2], x, sorted_4[3])
+    return (sorted_4[0], sorted_4[1], sorted_4[2], sorted_4[3], x)
+
+
+def score_hand_over_starters(kept_hand, starters):
+    """
+    Score a kept hand of 4 cards against a list of starter cards.
+    Pre-computes hand-invariant properties to optimize performance.
+    """
+    sorted_kept_indices = sorted([c.index for c in kept_hand])
+
+    kept_hand_suits = [c.suit for c in kept_hand]
+    is_flush = (
+        kept_hand_suits[0]
+        == kept_hand_suits[1]
+        == kept_hand_suits[2]
+        == kept_hand_suits[3]
+    )
+    flush_suit = kept_hand_suits[0] if is_flush else -1
+
+    jack_suits = {c.suit for c in kept_hand if c.index == JACK_INDEX}
+
+    scores = {}
+    for starter in starters:
+        # 1. Pairs, runs, fifteens points (cached)
+        hand_combo = insert_sorted(sorted_kept_indices, starter.index)
+        pts = cached_pairs_runs_and_fifteens_points(hand_combo)
+
+        # 2. Flush points
+        # is_crib=False because we are scoring the opponent's kept hand, not a crib.
+        if is_flush:
+            pts += 5 if starter.suit == flush_suit else 4
+
+        # 3. Nobs points
+        if starter.suit in jack_suits:
+            pts += 1
+
+        scores[starter] = pts
+
+    return scores

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -36,6 +36,7 @@ from artifact_pipeline.adapter import (  # noqa: E402
     BEST_STATIC_SELECT_PONE_KEPT_CARDS,
     BEST_STATIC_SELECT_DEALER_KEPT_CARDS,
     get_canonical_pairs,
+    score_hand_over_starters,
 )
 
 DEFAULT_OUTPUT_PATH = "expected_crib_points.json"
@@ -117,32 +118,39 @@ def select_opponent_kept_cards_dynamic(
     deck_set_to_use = DECK_SET
     starters = [card for card in deck_set_to_use if card not in opponent_dealt]
 
+    # Pre-build lookup table for policy EV by rank to avoid repeated dictionary and statistics logic.
+    # We only look up the canonical pairs that actually could be formed by discarding from opponent_dealt.
+    # Since there are only 15 combinations of 4 cards, there are 15 possible canonical pairs.
+    ev_lookups = {}
     for kept_combination in itertools.combinations(opponent_dealt, 4):
-        kept_hand = list(kept_combination)
-        # Calculate average hand score
-        total_hand_score = 0
-        for starter in starters:
-            total_hand_score += score_hand_and_starter(kept_hand, starter)
-        average_hand_score = total_hand_score / len(starters)
-
-        # Calculate average crib score using generation_accumulators
-        discarded = [c for c in opponent_dealt if c not in kept_hand]
+        discarded = [c for c in opponent_dealt if c not in kept_combination]
         canonical_pair = cards_to_canonical(discarded[0], discarded[1])
 
-        total_crib_score = 0.0
-        for starter in starters:
-            starter_rank = Index.indices[starter.index]
-            acc = (
-                generation_accumulators.get(canonical_pair, {})
-                .get(opp_role, {})
-                .get(starter_rank)
-            )
-            if acc:
-                stats = accumulator_to_statistics(acc)
-                mu = policy_mean(stats) if stats is not None else 0.0
-            else:
-                mu = 0.0
-            total_crib_score += mu
+        if canonical_pair not in ev_lookups:
+            ev_by_rank = [0.0] * 13
+            pair_data = generation_accumulators.get(canonical_pair) or {}
+            player_data = pair_data.get(opp_role) or {}
+            for r in range(13):
+                acc = player_data.get(Index.indices[r])
+                if acc:
+                    stats = accumulator_to_statistics(acc)
+                    ev_by_rank[r] = policy_mean(stats) if stats is not None else 0.0
+            ev_lookups[canonical_pair] = ev_by_rank
+
+    for kept_combination in itertools.combinations(opponent_dealt, 4):
+        kept_hand = list(kept_combination)
+
+        # 1. Calculate average hand score using our optimized batch scoring helper
+        hand_scores = score_hand_over_starters(kept_hand, starters)
+        total_hand_score = sum(hand_scores.values())
+        average_hand_score = total_hand_score / len(starters)
+
+        # 2. Calculate average crib score using the pre-computed policy EV table
+        discarded = [c for c in opponent_dealt if c not in kept_hand]
+        canonical_pair = cards_to_canonical(discarded[0], discarded[1])
+        ev_by_rank = ev_lookups[canonical_pair]
+
+        total_crib_score = sum(ev_by_rank[starter.index] for starter in starters)
         average_crib_score = total_crib_score / len(starters)
 
         if plus_crib:
@@ -762,8 +770,8 @@ def run_generation(
                         generation_accumulators=generation_accumulators,
                     )
                     made_progress = True
-                if checkpoint:
-                    checkpoint()
+    if made_progress and checkpoint:
+        checkpoint()
     return made_progress
 
 

--- a/artifact_pipeline/test_adapter.py
+++ b/artifact_pipeline/test_adapter.py
@@ -8,6 +8,7 @@ from artifact_pipeline.adapter import (
     cached_pairs_runs_and_fifteens_points,
     BEST_STATIC_SELECT_PONE_KEPT_CARDS,
     BEST_STATIC_SELECT_DEALER_KEPT_CARDS,
+    score_hand_over_starters,
 )
 
 
@@ -21,6 +22,7 @@ class TestAdapter(unittest.TestCase):
         self.assertIsNotNone(cached_pairs_runs_and_fifteens_points)
         self.assertIsNotNone(BEST_STATIC_SELECT_PONE_KEPT_CARDS)
         self.assertIsNotNone(BEST_STATIC_SELECT_DEALER_KEPT_CARDS)
+        self.assertIsNotNone(score_hand_over_starters)
 
     def test_card_creation(self):
         """Test basic Card interaction via adapter."""
@@ -44,6 +46,18 @@ class TestAdapter(unittest.TestCase):
         starter = Card(4, 0)
         score = score_hand_and_starter(kept, starter, is_crib=True)
         self.assertTrue(isinstance(score, int))
+
+    def test_score_hand_over_starters(self):
+        """Test score_hand_over_starters matches score_hand_and_starter for all deck starters."""
+        kept = [Card(0, 0), Card(1, 0), Card(2, 0), Card(10, 0)]
+        starters = [card for card in DECK_SET if card not in kept]
+
+        scores = score_hand_over_starters(kept, starters)
+
+        self.assertEqual(len(scores), len(starters))
+        for starter in starters:
+            expected = score_hand_and_starter(kept, starter, is_crib=False)
+            self.assertEqual(scores[starter], expected)
 
 
 if __name__ == "__main__":

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -378,7 +378,7 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(
             minimum_completed_sample_count(accumulators, ["A_A_Unsuited"]), 1
         )
-        self.assertEqual(len(checkpoint_calls), 2)
+        self.assertEqual(len(checkpoint_calls), 1)
 
     def test_run_generation_no_progress(self):
         args = argparse.Namespace(
@@ -1429,10 +1429,10 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         mock_accumulators = {
             "2_3_Unsuited": {
                 "Dealer": {
-                    0: {"n": 10, "sum": 20.0, "m2": 0.0},
+                    0: {"n": 10, "sum": 20.0, "sum_squares": 40.0},
                 },
                 "Pone": {
-                    0: {"n": 10, "sum": 20.0, "m2": 0.0},
+                    0: {"n": 10, "sum": 20.0, "sum_squares": 40.0},
                 },
             }
         }
@@ -1445,6 +1445,33 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
             "Pone", dealt, mock_accumulators
         )
         self.assertEqual(len(kept_dyn_pone), 4)
+
+        # 3. Test branch coverage for missing player_data and missing acc in select_opponent_kept_cards_dynamic
+        # "5_6_Suited" is formed when keeping Card(0,0), Card(1,0), Card(2,0), Card(3,0)
+        # and discarding Card(4,0), Card(5,0).
+        mock_accumulators_coverage = {
+            "5_6_Suited": {
+                "Dealer": {},  # empty player_data
+                "Pone": {
+                    "A": {
+                        "n": 10,
+                        "sum": 20.0,
+                        "sum_squares": 40.0,
+                    },  # only rank A is present, others missing
+                },
+            }
+        }
+        # Call with player="Pone" (opp_role="Dealer") to trigger missing player_data
+        kept_cov_dealer = select_opponent_kept_cards_dynamic(
+            "Pone", dealt, mock_accumulators_coverage
+        )
+        self.assertEqual(len(kept_cov_dealer), 4)
+
+        # Call with player="Dealer" (opp_role="Pone") to trigger missing acc for ranks other than A
+        kept_cov_pone = select_opponent_kept_cards_dynamic(
+            "Dealer", dealt, mock_accumulators_coverage
+        )
+        self.assertEqual(len(kept_cov_pone), 4)
 
     def test_main_negative_convergence_threshold(self):
         """Test that main rejects a negative convergence threshold."""


### PR DESCRIPTION
Consolidate checkpoint calls in `run_generation` to write to disk once per batch rather than per player-pair combination, and optimize `select_opponent_kept_cards_dynamic` using a pre-calculated policy EV lookup table and batch hand scoring.