### PR TITLE
ci: ignore astroid 4.1 upgrades in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "astroid"
+        versions: ["^4.1.0"]
     groups:
       pip-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "astroid"
-        versions: ["^4.1.0"]
+        versions: ["4.1.0", "4.1.1", "4.1.2"]
     groups:
       pip-dependencies:
         patterns:


### PR DESCRIPTION
Ignore astroid v4.1.x updates under pip ecosystem in dependabot.yml. This avoids conflicts with pylint v4.0.x which requires astroid <= 4.1.dev0, resolving pip install dependency resolution failures in GHA.