### PR TITLE
[codex] Expand expected crib artifact

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -52,11 +52,13 @@ jobs:
         run: |
           python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=300 --max-generations=1 --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
-      # Bounded with --max-generations=1 because the analytical bootstrap is already converged.
+      # Bounded because the analytical bootstrap is already converged. The
+      # expanded artifact is about 1.56x slower locally; 24k samples keeps the
+      # historical 4h43m production run comfortably below the 6h Actions limit.
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=32000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=24000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,14 @@ request because of permissions, use another authenticated path such as the
 GitHub CLI or GitHub web UI rather than changing the branch or pushing to
 `main`.
 
+When an app or connector reports expired GitHub authentication, do not assume
+all GitHub access is unavailable. First run `gh auth status` to check whether
+the GitHub CLI still has a valid keyring token. If it does, use `gh pr view`
+for pull request status and `gh api graphql` for review-thread state before
+asking the human maintainer to reauthenticate the connector. If CLI
+authentication also fails, ask the maintainer to run `gh auth login` or
+`gh auth refresh` before continuing GitHub work.
+
 If GitHub review comments exist, inspect their current thread status and address
 unresolved comments before requesting review again. Reply clearly when an agent
 implemented a change on behalf of a human.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,10 +356,12 @@ can destabilize GitHub review anchors and make human review harder. Use additive
 commits unless a human maintainer explicitly asks for history rewriting.
 
 When an AI agent posts or edits pull request prose, comments, summaries, or
-resolution notes, attribute the prose to the agent, for example "OpenAI Codex /
-me". Prefer natural Markdown paragraphs for GitHub-rendered PR prose; do not
-hard-wrap prose in PR descriptions or comments when GitHub's renderer will wrap
-it for the viewer.
+resolution notes that a human maintainer has not reviewed, attribute the prose
+to the agent alone, for example "OpenAI Codex". Do not use ambiguous shared
+attribution such as "OpenAI Codex / me" unless the human maintainer explicitly
+approved that wording. Prefer natural Markdown paragraphs for GitHub-rendered
+PR prose; do not hard-wrap prose in PR descriptions or comments when GitHub's
+renderer will wrap it for the viewer.
 
 Near the end of this section, observe these boundaries: do not claim an issue is
 complete until requested files are updated, required constraints are represented

--- a/README.md
+++ b/README.md
@@ -190,6 +190,32 @@ are used for the next generation's discard policy. Reporting and table
 summaries should prefer the measured statistics unless they are intentionally
 inspecting policy-transition state.
 
+The Monte Carlo table preserves the 169 canonical top-level discard keys. Each
+discard key contains `Dealer` and `Pone` role entries, and each role contains
+starter-rank buckets keyed by `A,2,3,4,5,6,7,8,9,T,J,Q,K`. The root of each
+starter-rank bucket continues to expose `mu`, `se`, `n`, and optional support
+fields so existing consumers can keep reading
+`table[pairKey][role][starterRank].mu`.
+
+Newer generated tables also include a `points` object in each starter bucket.
+The point categories are `total`, `fifteens`, `pairs`, `runs`, `flushes`, and
+`nobs`; each category uses the same statistics shape as the root bucket. The
+root `mu` remains the total crib EV, and `points.total.mu` is the same value
+recorded explicitly for consumers that render point-type breakdowns.
+
+For suited different-rank discard keys, starter buckets may also include
+`starter_suit_relation`. Its possible keys are `matching_discard_suit` and
+`non_matching_discard_suit`, each containing the same total and point-type
+statistics shape. These buckets split starters of the same rank by whether the
+starter's suit matches the suited discard suit. Same-rank pairs are always
+unsuited, so same-rank buckets never use `starter_suit_relation` and same-rank
+`Suited` keys remain impossible.
+
+The v2 Monte Carlo artifact format intentionally rejects resuming v1 generator
+checkpoints, because v1 checkpoints do not contain point-type or starter-suit
+relation accumulators. Start v2 production runs with `--no-resume`, optionally
+using an analytical bootstrap as the policy baseline.
+
 Summarize a generated table:
 
 ```sh

--- a/artifact_pipeline/adapter.py
+++ b/artifact_pipeline/adapter.py
@@ -14,6 +14,11 @@ from simulate_cribbage_games import (  # noqa: E402
     Index,
     DECK_SET,
     score_hand_and_starter,
+    fifteens_points,
+    pairs_points,
+    runs_points,
+    flush_points,
+    nobs_points,
     cached_pairs_runs_and_fifteens_points,
     BEST_STATIC_SELECT_PONE_KEPT_CARDS,
     BEST_STATIC_SELECT_DEALER_KEPT_CARDS,
@@ -24,6 +29,7 @@ __all__ = [
     "Index",
     "DECK_SET",
     "score_hand_and_starter",
+    "score_hand_and_starter_breakdown",
     "cached_pairs_runs_and_fifteens_points",
     "BEST_STATIC_SELECT_PONE_KEPT_CARDS",
     "BEST_STATIC_SELECT_DEALER_KEPT_CARDS",
@@ -56,6 +62,26 @@ def get_canonical_pairs():
                 pairs.append(f"{rank1}_{rank2}_Unsuited")
 
     return pairs
+
+
+def score_hand_and_starter_breakdown(kept_hand, starter, is_crib=False):
+    """Score a hand and starter with cribbage-rule point categories."""
+    hand_plus_starter = [*kept_hand, starter]
+    sorted_indices = tuple(sorted(card.index for card in hand_plus_starter))
+    fifteens = fifteens_points(hand_plus_starter)
+    pairs = pairs_points(sorted_indices)
+    runs = runs_points(sorted_indices)
+    flushes = flush_points(kept_hand, starter, is_crib=is_crib)
+    nobs = nobs_points(kept_hand, starter)
+    total = fifteens + pairs + runs + flushes + nobs
+    return {
+        "total": total,
+        "fifteens": fifteens,
+        "pairs": pairs,
+        "runs": runs,
+        "flushes": flushes,
+        "nobs": nobs,
+    }
 
 
 JACK_INDEX = 10

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -33,6 +33,7 @@ from artifact_pipeline.adapter import (  # noqa: E402
     Card,
     DECK_SET,
     score_hand_and_starter,
+    score_hand_and_starter_breakdown,
     BEST_STATIC_SELECT_PONE_KEPT_CARDS,
     BEST_STATIC_SELECT_DEALER_KEPT_CARDS,
     get_canonical_pairs,
@@ -42,7 +43,20 @@ from artifact_pipeline.adapter import (  # noqa: E402
 DEFAULT_OUTPUT_PATH = "expected_crib_points.json"
 DEFAULT_CHECKPOINT_FREQUENCY = 100
 METADATA_KEY = "__metadata__"
-GENERATION_METHOD = "artifact_pipeline.generate_table.v1"
+GENERATION_METHOD = "artifact_pipeline.generate_table.v2"
+POINT_TYPES = ("total", "fifteens", "pairs", "runs", "flushes", "nobs")
+MATCHING_DISCARD_SUIT = "matching_discard_suit"
+NON_MATCHING_DISCARD_SUIT = "non_matching_discard_suit"
+ROOT_ACCUMULATOR_KEYS = (
+    "n",
+    "sum",
+    "sum_squares",
+    "sum_weights_squared",
+    "mu",
+    "se",
+    "policy_mu",
+    "policy_se",
+)
 
 
 def canonical_to_cards(canonical_pair):
@@ -221,7 +235,33 @@ def update_accumulator(accumulator, value, weight=1.0):
     accumulator["sum_weights_squared"] += weight * weight
 
 
-def accumulator_to_statistics(accumulator):
+def update_breakdown_accumulator(accumulator, breakdown, weight=1.0):
+    update_accumulator(accumulator, breakdown["total"], weight=weight)
+    points = accumulator.setdefault("points", {})
+    for point_type in POINT_TYPES:
+        update_accumulator(
+            points.setdefault(point_type, empty_accumulator()),
+            breakdown[point_type],
+            weight=weight,
+        )
+
+
+def update_relation_accumulator(accumulator, relation, breakdown, weight=1.0):
+    relation_accumulators = accumulator.setdefault("starter_suit_relation", {})
+    update_breakdown_accumulator(
+        relation_accumulators.setdefault(relation, empty_accumulator()),
+        breakdown,
+        weight=weight,
+    )
+
+
+def root_accumulator_copy(accumulator):
+    return {
+        key: value for key, value in accumulator.items() if key in ROOT_ACCUMULATOR_KEYS
+    }
+
+
+def _root_accumulator_to_statistics(accumulator):
     n = accumulator["n"]
     if n == 0:
         if "mu" in accumulator:
@@ -262,6 +302,34 @@ def accumulator_to_statistics(accumulator):
     if "policy_mu" in accumulator:
         statistics["policy_mu"] = accumulator["policy_mu"]
         statistics["policy_se"] = accumulator.get("policy_se", 0.0)
+    return statistics
+
+
+def accumulator_to_statistics(accumulator, include_nested=True):
+    statistics = _root_accumulator_to_statistics(accumulator)
+    if statistics is None:
+        return None
+    if not include_nested:
+        return statistics
+
+    points = {}
+    for point_type, point_accumulator in accumulator.get("points", {}).items():
+        point_statistics = accumulator_to_statistics(point_accumulator)
+        if point_statistics is not None:
+            points[point_type] = point_statistics
+    if points:
+        statistics["points"] = points
+
+    relation_statistics = {}
+    for relation, relation_accumulator in accumulator.get(
+        "starter_suit_relation", {}
+    ).items():
+        stats = accumulator_to_statistics(relation_accumulator)
+        if stats is not None:
+            relation_statistics[relation] = stats
+    if relation_statistics:
+        statistics["starter_suit_relation"] = relation_statistics
+
     return statistics
 
 
@@ -309,6 +377,16 @@ def statistics_to_accumulator(statistics):
     if "policy_mu" in statistics:
         accumulator["policy_mu"] = statistics["policy_mu"]
         accumulator["policy_se"] = statistics.get("policy_se", 0.0)
+    if "points" in statistics:
+        accumulator["points"] = {
+            point_type: statistics_to_accumulator(point_stats)
+            for point_type, point_stats in statistics["points"].items()
+        }
+    if "starter_suit_relation" in statistics:
+        accumulator["starter_suit_relation"] = {
+            relation: statistics_to_accumulator(relation_stats)
+            for relation, relation_stats in statistics["starter_suit_relation"].items()
+        }
     return accumulator
 
 
@@ -316,19 +394,19 @@ def blend_policy_accumulators(prior_accumulator, measured_accumulator, dampening
     """Blend policy EV while retaining honest pooled measurement statistics."""
     if measured_accumulator is None:
         return (
-            dict(prior_accumulator)
+            root_accumulator_copy(prior_accumulator)
             if prior_accumulator is not None
             else empty_accumulator()
         )
     if prior_accumulator is None:
-        return dict(measured_accumulator)
+        return root_accumulator_copy(measured_accumulator)
 
     prior_stats = accumulator_to_statistics(prior_accumulator)
     measured_stats = accumulator_to_statistics(measured_accumulator)
     if prior_stats is None:
-        return dict(measured_accumulator)
+        return root_accumulator_copy(measured_accumulator)
     if measured_stats is None:
-        return dict(prior_accumulator)
+        return root_accumulator_copy(prior_accumulator)
 
     prior_policy_mu = prior_stats.get("policy_mu", prior_stats["mu"])
     prior_policy_se = prior_stats.get("policy_se", prior_stats["se"])
@@ -353,7 +431,7 @@ def blend_policy_accumulators(prior_accumulator, measured_accumulator, dampening
     }
 
 
-def serialize_accumulators(accumulators):
+def serialize_accumulators(accumulators, include_nested=True):
     if accumulators is None:
         return None
     serialized = {}
@@ -364,7 +442,7 @@ def serialize_accumulators(accumulators):
         for player, player_data in pair_data.items():
             serialized[pair][player] = {}
             for cut_card, acc in player_data.items():
-                stats = accumulator_to_statistics(acc)
+                stats = accumulator_to_statistics(acc, include_nested=include_nested)
                 if stats is not None:
                     serialized[pair][player][cut_card] = stats
     return serialized
@@ -391,7 +469,9 @@ def build_metadata(
         "seed": seed,
         "seed_was_specified": seed is not None,
         "generation": generation,
-        "generation_accumulators": serialize_accumulators(generation_accumulators),
+        "generation_accumulators": serialize_accumulators(
+            generation_accumulators, include_nested=False
+        ),
         "use_control_variates": use_control_variates,
     }
 
@@ -476,7 +556,9 @@ def load_or_initialize_accumulators(
         bootstrap_accumulators, _ = load_output(bootstrap_path)
         metadata = {
             "generation": 0,
-            "generation_accumulators": serialize_accumulators(bootstrap_accumulators),
+            "generation_accumulators": serialize_accumulators(
+                bootstrap_accumulators, include_nested=False
+            ),
             "use_control_variates": use_control_variates,
         }
         return {}, metadata
@@ -505,7 +587,42 @@ def sample_rng_for_index(rng, seed, canonical_pair, player, sample_index):
     return random.Random(f"{seed}:{canonical_pair}:{player}:{sample_index}")
 
 
-def score_crib_sample(
+def average_breakdowns(breakdowns):
+    return {
+        point_type: sum(breakdown[point_type] for breakdown in breakdowns)
+        / len(breakdowns)
+        for point_type in POINT_TYPES
+    }
+
+
+def starter_suit_relation(canonical_pair, starter):
+    parts = canonical_pair.split("_")
+    if parts[0] == parts[1] or parts[2] != "Suited":
+        return None
+    return MATCHING_DISCARD_SUIT if starter.suit == 0 else NON_MATCHING_DISCARD_SUIT
+
+
+def average_starter_breakdowns(starter_breakdowns):
+    return average_breakdowns([breakdown for _starter, breakdown in starter_breakdowns])
+
+
+def relation_breakdowns_for_starters(canonical_pair, starter_breakdowns):
+    relation_breakdowns = {}
+    for relation in (MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT):
+        breakdowns = [
+            breakdown
+            for starter, breakdown in starter_breakdowns
+            if starter_suit_relation(canonical_pair, starter) == relation
+        ]
+        if breakdowns:
+            relation_breakdowns[relation] = (
+                average_breakdowns(breakdowns),
+                len(breakdowns),
+            )
+    return relation_breakdowns
+
+
+def score_crib_sample_breakdown(
     discarded_cards,
     remaining_deck,
     player,
@@ -522,11 +639,28 @@ def score_crib_sample(
     ]
     cut_card = sample_rng.choice(remaining_after_deal)
     crib_hand = discarded_cards + opponent_discards
-    score = score_hand_and_starter(crib_hand, cut_card, is_crib=True)
-    return cut_card, score
+    breakdown = score_hand_and_starter_breakdown(crib_hand, cut_card, is_crib=True)
+    return cut_card, breakdown
 
 
-def score_crib_sample_ev(
+def score_crib_sample(
+    discarded_cards,
+    remaining_deck,
+    player,
+    sample_rng,
+    generation_accumulators=None,
+):
+    cut_card, breakdown = score_crib_sample_breakdown(
+        discarded_cards,
+        remaining_deck,
+        player,
+        sample_rng,
+        generation_accumulators,
+    )
+    return cut_card, breakdown["total"]
+
+
+def score_crib_sample_ev_breakdown(
     discarded_cards,
     remaining_deck,
     player,
@@ -542,18 +676,70 @@ def score_crib_sample_ev(
         card for card in remaining_deck if card not in opponent_dealt
     ]
     crib_hand = discarded_cards + opponent_discards
+    canonical_pair = cards_to_canonical(discarded_cards[0], discarded_cards[1])
 
     results = []
     for c in range(13):
         starters = [card for card in remaining_after_deal if card.index == c]
         if starters:
-            total_score = sum(
-                score_hand_and_starter(crib_hand, starter, is_crib=True)
+            starter_breakdowns = [
+                (
+                    starter,
+                    score_hand_and_starter_breakdown(crib_hand, starter, is_crib=True),
+                )
                 for starter in starters
+            ]
+            results.append(
+                (
+                    c,
+                    average_starter_breakdowns(starter_breakdowns),
+                    len(starters),
+                    relation_breakdowns_for_starters(
+                        canonical_pair, starter_breakdowns
+                    ),
+                )
             )
-            expected_score = total_score / len(starters)
-            results.append((c, expected_score, len(starters)))
     return results
+
+
+def score_crib_sample_ev(
+    discarded_cards,
+    remaining_deck,
+    player,
+    sample_rng,
+    generation_accumulators=None,
+):
+    results = score_crib_sample_ev_breakdown(
+        discarded_cards,
+        remaining_deck,
+        player,
+        sample_rng,
+        generation_accumulators,
+    )
+    return [
+        (rank, breakdown["total"], num_starters)
+        for rank, breakdown, num_starters, _relations in results
+    ]
+
+
+def update_cv_result_accumulators(accumulators, canonical_pair, player, result):
+    c, breakdown, num_starters, relation_breakdowns = result
+    weight = 13.0 * num_starters / 44.0
+    accumulator = get_cut_accumulator(
+        accumulators, canonical_pair, player, Index.indices[c]
+    )
+    update_breakdown_accumulator(accumulator, breakdown, weight=weight)
+    for relation, (
+        relation_breakdown,
+        relation_starters,
+    ) in relation_breakdowns.items():
+        relation_weight = 13.0 * relation_starters / 44.0
+        update_relation_accumulator(
+            accumulator,
+            relation,
+            relation_breakdown,
+            weight=relation_weight,
+        )
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -566,20 +752,15 @@ def _run_cv_sample(
     sample_rng,
     generation_accumulators,
 ):
-    results = score_crib_sample_ev(
+    results = score_crib_sample_ev_breakdown(
         discarded_cards,
         remaining_deck,
         player,
         sample_rng,
         generation_accumulators,
     )
-    for c, expected_score, num_starters in results:
-        weight = 13.0 * num_starters / 44.0
-        update_accumulator(
-            get_cut_accumulator(accumulators, canonical_pair, player, Index.indices[c]),
-            expected_score,
-            weight=weight,
-        )
+    for result in results:
+        update_cv_result_accumulators(accumulators, canonical_pair, player, result)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -592,19 +773,20 @@ def _run_mc_sample(
     sample_rng,
     generation_accumulators,
 ):
-    cut_card, score = score_crib_sample(
+    cut_card, breakdown = score_crib_sample_breakdown(
         discarded_cards,
         remaining_deck,
         player,
         sample_rng,
         generation_accumulators,
     )
-    update_accumulator(
-        get_cut_accumulator(
-            accumulators, canonical_pair, player, Index.indices[cut_card.index]
-        ),
-        score,
+    accumulator = get_cut_accumulator(
+        accumulators, canonical_pair, player, Index.indices[cut_card.index]
     )
+    update_breakdown_accumulator(accumulator, breakdown)
+    relation = starter_suit_relation(canonical_pair, cut_card)
+    if relation is not None:
+        update_relation_accumulator(accumulator, relation, breakdown)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -722,7 +722,9 @@ def score_crib_sample_ev(
     ]
 
 
-def update_cv_result_accumulators(accumulators, canonical_pair, player, result):
+def update_control_variates_result_accumulators(
+    accumulators, canonical_pair, player, result
+):
     c, breakdown, num_starters, relation_breakdowns = result
     weight = 13.0 * num_starters / 44.0
     accumulator = get_cut_accumulator(
@@ -743,7 +745,7 @@ def update_cv_result_accumulators(accumulators, canonical_pair, player, result):
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
-def _run_cv_sample(
+def _run_control_variates_sample(
     accumulators,
     canonical_pair,
     player,
@@ -760,7 +762,9 @@ def _run_cv_sample(
         generation_accumulators,
     )
     for result in results:
-        update_cv_result_accumulators(accumulators, canonical_pair, player, result)
+        update_control_variates_result_accumulators(
+            accumulators, canonical_pair, player, result
+        )
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -817,7 +821,7 @@ def run_monte_carlo_into_accumulators(
             sampling["first_sample_index"] + sample_offset,
         )
         if use_cv:
-            _run_cv_sample(
+            _run_control_variates_sample(
                 accumulators,
                 canonical_pair,
                 player,

--- a/artifact_pipeline/test_adapter.py
+++ b/artifact_pipeline/test_adapter.py
@@ -5,6 +5,7 @@ from artifact_pipeline.adapter import (
     Index,
     DECK_SET,
     score_hand_and_starter,
+    score_hand_and_starter_breakdown,
     cached_pairs_runs_and_fifteens_points,
     BEST_STATIC_SELECT_PONE_KEPT_CARDS,
     BEST_STATIC_SELECT_DEALER_KEPT_CARDS,
@@ -19,6 +20,7 @@ class TestAdapter(unittest.TestCase):
         self.assertIsNotNone(Index)
         self.assertIsNotNone(DECK_SET)
         self.assertIsNotNone(score_hand_and_starter)
+        self.assertIsNotNone(score_hand_and_starter_breakdown)
         self.assertIsNotNone(cached_pairs_runs_and_fifteens_points)
         self.assertIsNotNone(BEST_STATIC_SELECT_PONE_KEPT_CARDS)
         self.assertIsNotNone(BEST_STATIC_SELECT_DEALER_KEPT_CARDS)
@@ -46,6 +48,23 @@ class TestAdapter(unittest.TestCase):
         starter = Card(4, 0)
         score = score_hand_and_starter(kept, starter, is_crib=True)
         self.assertTrue(isinstance(score, int))
+
+    def test_score_hand_and_starter_breakdown(self):
+        """Test crib scoring categories are exposed without changing totals."""
+        kept = [Card(0, 0), Card(1, 0), Card(2, 0), Card(10, 0)]
+        starter = Card(3, 0)
+
+        breakdown = score_hand_and_starter_breakdown(kept, starter, is_crib=True)
+
+        self.assertEqual(breakdown["fifteens"], 4)
+        self.assertEqual(breakdown["pairs"], 0)
+        self.assertEqual(breakdown["runs"], 4)
+        self.assertEqual(breakdown["flushes"], 5)
+        self.assertEqual(breakdown["nobs"], 1)
+        self.assertEqual(breakdown["total"], 14)
+        self.assertEqual(
+            breakdown["total"], score_hand_and_starter(kept, starter, is_crib=True)
+        )
 
     def test_score_hand_over_starters(self):
         """Test score_hand_over_starters matches score_hand_and_starter for all deck starters."""

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -651,13 +651,13 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertAlmostEqual(typical_se, 0.2, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
-        # 2.4 Add a degenerate CV bucket (n > 1 but denom <= 0): standard error should be ignored
+        # 2.4 Add a degenerate control-variates bucket: standard error is ignored.
         acc5 = get_cut_accumulator(accumulators, "A_A_Unsuited", "Pone", "4")
         acc5.update(
             {"n": 1.18, "sum": 5.9, "sum_squares": 29.5, "sum_weights_squared": 1.3924}
         )
         typical_se, max_se = get_se_summary(accumulators, ["A_A_Unsuited"])
-        # Still median = 0.2, max = 0.5 (the degenerate CV bucket is skipped)
+        # Still median = 0.2, max = 0.5 (the degenerate bucket is skipped)
         self.assertAlmostEqual(typical_se, 0.2, places=5)
         self.assertAlmostEqual(max_se, 0.5, places=5)
 
@@ -2763,7 +2763,7 @@ class TestControlVariates(unittest.TestCase):
             self.assertFalse(sampling_dict["use_control_variates"])
 
     def test_control_variates_resume_validation(self):
-        """Test that validate_resume_metadata rejects incompatible CV configurations."""
+        """Test that validate_resume_metadata rejects control-variates mismatches."""
         meta_cv = {
             "generation_method": GENERATION_METHOD,
             "seed": 42,
@@ -2775,7 +2775,7 @@ class TestControlVariates(unittest.TestCase):
             "use_control_variates": False,
         }
 
-        # 1. Matching CV should pass
+        # 1. Matching control-variates settings should pass
         validate_resume_metadata(
             meta_cv, 42, "test_path.json", use_control_variates=True
         )
@@ -2783,7 +2783,7 @@ class TestControlVariates(unittest.TestCase):
             meta_mc, 42, "test_path.json", use_control_variates=False
         )
 
-        # 2. Mismatched CV should raise ValueError
+        # 2. Mismatched control-variates settings should raise ValueError
         with self.assertRaises(ValueError) as ctx:
             validate_resume_metadata(
                 meta_cv, 42, "test_path.json", use_control_variates=False
@@ -2970,7 +2970,7 @@ class TestControlVariates(unittest.TestCase):
         """Test that reached_target_sample_count handles float deal counts near target."""
         accumulators = {}
         # Target = 100
-        # If deal count is 99.9999999999 (under CV, sum of weights is 1299.9999999999)
+        # Under control variates, deal count 99.9999999999 weighs as 1299.9999999999.
         # 99.9999999999 >= 100 - 1e-9 is True.
         acc_dl = get_cut_accumulator(accumulators, "A_A_Unsuited", "Dealer", "A")
         acc_dl["n"] = 1299.9999999999

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -21,6 +21,8 @@ from artifact_pipeline.generate_table import (
     get_canonical_pairs,
     canonical_to_cards,
     run_monte_carlo,
+    score_crib_sample,
+    score_crib_sample_ev,
     run_monte_carlo_into_accumulators,
     compute_statistics,
     run_generation,
@@ -44,6 +46,9 @@ from artifact_pipeline.generate_table import (
     GENERATION_METHOD,
     get_cut_accumulator,
     update_accumulator,
+    POINT_TYPES,
+    MATCHING_DISCARD_SUIT,
+    NON_MATCHING_DISCARD_SUIT,
 )
 from artifact_pipeline.adapter import (
     Card,
@@ -326,6 +331,181 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(output["A_A_Unsuited"]["Dealer"], {})
         self.assertEqual(output["__metadata__"], build_metadata(None))
 
+    def test_accumulators_to_output_includes_point_breakdown(self):
+        accumulators = {}
+        run_monte_carlo_into_accumulators(
+            accumulators,
+            "A_2_Unsuited",
+            "Dealer",
+            1,
+            {
+                "rng": random.Random(42),
+                "first_sample_index": 0,
+                "seed": 42,
+                "use_control_variates": False,
+            },
+        )
+
+        output = accumulators_to_output(accumulators, pairs=["A_2_Unsuited"])
+        dealer_buckets = output["A_2_Unsuited"]["Dealer"]
+
+        self.assertEqual(set(output) - {METADATA_KEY}, {"A_2_Unsuited"})
+        self.assertEqual(len(output) - 1, 1)
+        bucket = next(iter(dealer_buckets.values()))
+        self.assertEqual(set(bucket["points"]), set(POINT_TYPES))
+        self.assertAlmostEqual(bucket["points"]["total"]["mu"], bucket["mu"])
+        component_total = sum(
+            bucket["points"][point_type]["mu"]
+            for point_type in POINT_TYPES
+            if point_type != "total"
+        )
+        self.assertAlmostEqual(component_total, bucket["points"]["total"]["mu"])
+
+    def test_same_rank_pair_has_no_starter_suit_relation(self):
+        accumulators = {}
+        run_monte_carlo_into_accumulators(
+            accumulators,
+            "A_A_Unsuited",
+            "Dealer",
+            1,
+            {
+                "rng": random.Random(42),
+                "first_sample_index": 0,
+                "seed": 42,
+                "use_control_variates": True,
+            },
+        )
+
+        output = accumulators_to_output(accumulators, pairs=["A_A_Unsuited"])
+
+        self.assertNotIn("A_A_Suited", output)
+        for bucket in output["A_A_Unsuited"]["Dealer"].values():
+            self.assertNotIn("starter_suit_relation", bucket)
+
+    def test_suited_pair_has_matching_and_non_matching_starter_buckets(self):
+        accumulators = {}
+        run_monte_carlo_into_accumulators(
+            accumulators,
+            "A_2_Suited",
+            "Dealer",
+            1,
+            {
+                "rng": random.Random(42),
+                "first_sample_index": 0,
+                "seed": 42,
+                "use_control_variates": True,
+            },
+        )
+
+        output = accumulators_to_output(accumulators, pairs=["A_2_Suited"])
+        relation_sets = [
+            set(bucket.get("starter_suit_relation", {}))
+            for bucket in output["A_2_Suited"]["Dealer"].values()
+        ]
+
+        self.assertTrue(
+            {MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT} in relation_sets
+        )
+        for bucket in output["A_2_Suited"]["Dealer"].values():
+            for relation_bucket in bucket.get("starter_suit_relation", {}).values():
+                self.assertEqual(set(relation_bucket["points"]), set(POINT_TYPES))
+                self.assertAlmostEqual(
+                    relation_bucket["points"]["total"]["mu"],
+                    relation_bucket["mu"],
+                )
+
+    def test_v2_statistics_round_trip_preserves_nested_details(self):
+        statistics = {
+            "n": 2,
+            "mu": 7.0,
+            "se": 1.0,
+            "points": {
+                "total": {"n": 2, "mu": 7.0, "se": 1.0},
+                "fifteens": {"n": 2, "mu": 4.0, "se": 0.0},
+            },
+            "starter_suit_relation": {
+                MATCHING_DISCARD_SUIT: {
+                    "n": 1,
+                    "mu": 9.0,
+                    "se": 0.0,
+                    "points": {"total": {"n": 1, "mu": 9.0, "se": 0.0}},
+                }
+            },
+        }
+
+        accumulator = statistics_to_accumulator(statistics)
+
+        self.assertEqual(accumulator_to_statistics(accumulator), statistics)
+
+    def test_v1_statistics_round_trip_stays_root_only(self):
+        statistics = {"n": 2, "mu": 7.0, "se": 1.0}
+
+        accumulator = statistics_to_accumulator(statistics)
+
+        self.assertEqual(accumulator_to_statistics(accumulator), statistics)
+
+    def test_generation_metadata_serializes_root_policy_only(self):
+        accumulator = statistics_to_accumulator(
+            {
+                "n": 2,
+                "mu": 7.0,
+                "se": 1.0,
+                "points": {"total": {"n": 2, "mu": 7.0, "se": 1.0}},
+                "starter_suit_relation": {
+                    MATCHING_DISCARD_SUIT: {"n": 1, "mu": 9.0, "se": 0.0}
+                },
+            }
+        )
+
+        metadata = build_metadata(
+            None,
+            generation_accumulators={
+                "A_2_Suited": {"Dealer": {"A": accumulator}, "Pone": {}}
+            },
+        )
+        serialized = metadata["generation_accumulators"]["A_2_Suited"]["Dealer"]["A"]
+
+        self.assertEqual(serialized, {"n": 2, "mu": 7.0, "se": 1.0})
+
+    def test_empty_nested_accumulators_are_skipped(self):
+        accumulator = {
+            "n": 1,
+            "sum": 5.0,
+            "sum_squares": 25.0,
+            "points": {"total": empty_accumulator()},
+            "starter_suit_relation": {MATCHING_DISCARD_SUIT: empty_accumulator()},
+        }
+
+        statistics = accumulator_to_statistics(accumulator)
+
+        self.assertNotIn("points", statistics)
+        self.assertNotIn("starter_suit_relation", statistics)
+
+    def test_score_crib_sample_compatibility_wrappers(self):
+        discarded_cards = canonical_to_cards("A_2_Suited")
+        remaining_deck = [card for card in DECK_SET if card not in discarded_cards]
+
+        cut_card, score = score_crib_sample(
+            discarded_cards,
+            remaining_deck,
+            "Dealer",
+            random.Random(42),
+        )
+        ev_results = score_crib_sample_ev(
+            discarded_cards,
+            remaining_deck,
+            "Dealer",
+            random.Random(42),
+        )
+
+        self.assertTrue(cut_card in DECK_SET)
+        self.assertTrue(isinstance(score, int))
+        self.assertEqual(len(ev_results), len(Index.indices))
+        rank, expected_score, num_starters = ev_results[0]
+        self.assertTrue(isinstance(rank, int))
+        self.assertTrue(isinstance(expected_score, float))
+        self.assertGreater(num_starters, 0)
+
     def test_canonical_to_cards_errors(self):
         """Test error conditions in canonical_to_cards."""
         with self.assertRaises(ValueError):
@@ -359,6 +539,18 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
                 1,
                 {"rng": rng, "first_sample_index": 0, "seed": None},
             )
+
+    def test_resume_rejects_v1_generation_method(self):
+        metadata = {
+            "generation_method": "artifact_pipeline.generate_table.v1",
+            "seed": 42,
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            validate_resume_metadata(metadata, 42, "expected_crib_points.json")
+
+        self.assertTrue("artifact_pipeline.generate_table.v1" in str(ctx.exception))
+        self.assertTrue(GENERATION_METHOD in str(ctx.exception))
 
     def test_run_generation_infinite(self):
         args = argparse.Namespace(infinite=True, checkpoint_frequency=1, seed=42)
@@ -1235,7 +1427,7 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
                 json.dump(
                     {
                         "__metadata__": {
-                            "generation_method": "artifact_pipeline.generate_table.v1",
+                            "generation_method": GENERATION_METHOD,
                             "seed": 42,
                             "generation": 2,
                         },
@@ -1274,7 +1466,7 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
                 json.dump(
                     {
                         "__metadata__": {
-                            "generation_method": "artifact_pipeline.generate_table.v1",
+                            "generation_method": GENERATION_METHOD,
                             "seed": 42,
                             "generation": 2,
                         },

--- a/artifact_pipeline/test_summarize_table.py
+++ b/artifact_pipeline/test_summarize_table.py
@@ -141,6 +141,28 @@ class TestSummarizeTable(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(get_pair_stat(data, ("A", "A"), "Dealer", "mu", "actual"), 6.0)
 
+    def test_get_pair_stat_ignores_nested_point_details(self):
+        data = {
+            "A_A_Unsuited": {
+                "Dealer": {
+                    "A": {
+                        "n": 1,
+                        "mu": 5.0,
+                        "points": {"total": {"n": 1, "mu": 5.0, "se": 0.0}},
+                    },
+                    "2": {
+                        "n": 1,
+                        "mu": 7.0,
+                        "starter_suit_relation": {
+                            "matching_discard_suit": {"n": 1, "mu": 7.0}
+                        },
+                    },
+                }
+            }
+        }
+
+        self.assertEqual(get_pair_stat(data, ("A", "A"), "Dealer", "mu", "actual"), 6.0)
+
     def test_get_pair_stat_same_rank_suited_only_is_impossible(self):
         data = {
             "A_A_Unsuited": {

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -48,9 +48,14 @@ default skill for documentation and Python backend work.
 13. When publishing, verify the pushed branch and pull request URL. If a GitHub
    integration cannot create the PR, use another authenticated path instead of
    changing the branch or bypassing review.
-14. Before resolving a pull request review thread, reply with why the feedback is
+14. If a GitHub app or connector token expires, run `gh auth status` before
+   declaring GitHub work blocked. A valid CLI keyring token is enough to inspect
+   pull request status with `gh pr view` and review-thread state with
+   `gh api graphql`; ask for `gh auth login` or `gh auth refresh` only when CLI
+   authentication also fails.
+15. Before resolving a pull request review thread, reply with why the feedback is
    considered resolved and identify the agent or human making that assessment.
-15. Update `README.md`, `AGENTS.md`, and this file together when shared workflow
+16. Update `README.md`, `AGENTS.md`, and this file together when shared workflow
    guidance changes.
 
 ## Skill Authoring Rules
@@ -162,6 +167,12 @@ When publishing or updating a pull request, avoid force-pushing once review
 comments exist unless a human maintainer explicitly requests rewritten history.
 Attribute AI-written PR prose and comments to the agent, and avoid manual
 hard-wrapping in GitHub-rendered PR descriptions or comments.
+
+If a GitHub connector or app reports an expired token, check CLI authentication
+with `gh auth status` before stopping. When the CLI is authenticated, use
+`gh pr view` for current status and `gh api graphql` for review-thread details;
+only ask for a fresh sign-in when the CLI token is also invalid or lacks the
+required scope.
 
 Near the end of this section, observe these boundaries: do not lower coverage
 requirements, remove quality checks, add broad ignore comments, or refactor the

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -165,8 +165,11 @@ summary-table formatting, and impossible card states such as suited pairs.
 
 When publishing or updating a pull request, avoid force-pushing once review
 comments exist unless a human maintainer explicitly requests rewritten history.
-Attribute AI-written PR prose and comments to the agent, and avoid manual
-hard-wrapping in GitHub-rendered PR descriptions or comments.
+Attribute AI-written PR prose and comments to the agent alone when a human
+maintainer has not reviewed the wording. Do not use ambiguous shared
+attribution such as "OpenAI Codex / me" unless the human maintainer explicitly
+approved that wording. Avoid manual hard-wrapping in GitHub-rendered PR
+descriptions or comments.
 
 If a GitHub connector or app reports an expired token, check CLI authentication
 with `gh auth status` before stopping. When the CLI is authenticated, use


### PR DESCRIPTION
## Summary

PR body drafted by OpenAI Codex.

This implements issue #76 by expanding the expected crib points artifact while preserving the existing 169 discard-key top-level shape and current root `mu`/`se`/`n` consumer path.

- Adds v2 nested crib detail payloads for point-type scoring (`total`, `fifteens`, `pairs`, `runs`, `flushes`, `nobs`).
- Adds suited different-rank starter suit relation buckets for `matching_discard_suit` and `non_matching_suit`, while same-rank pairs remain unsuited only.
- Keeps root crib EV statistics as the compatibility path for existing consumers, summaries, and policy metadata.
- Rejects v1 resume into v2 generation so old partial tables are migrated intentionally instead of silently widening incomplete accumulators.
- Documents the v2 schema, migration behavior, and current runtime/artifact-size impact in the README.

Closes #76.

## Concrete Output Difference

The existing release artifact and this PR artifact both keep the same 169 discard keys. The old bucket shape was root statistics only:

```json
{
  "n": 24966.795455,
  "mu": 8.598286,
  "se": 0.023049,
  "sum_w2": 20791.942149
}
```

The new bucket keeps those root fields and adds expanded detail. For example, a suited `5_6_Suited` dealer crib bucket for starter `5` now has:

```json
{
  "n": 238.431818,
  "mu": 8.513011,
  "se": 0.233397,
  "sum_w2": 197.195764,
  "points": {
    "total": {"mu": 8.513011},
    "fifteens": {"mu": 4.532838},
    "pairs": {"mu": 2.285006},
    "runs": {"mu": 1.667906},
    "flushes": {"mu": 0.0},
    "nobs": {"mu": 0.027261}
  },
  "starter_suit_relation": {
    "non_matching_discard_suit": {
      "mu": 8.513011,
      "points": {
        "total": {"mu": 8.513011},
        "fifteens": {"mu": 4.532838},
        "pairs": {"mu": 2.285006},
        "runs": {"mu": 1.667906},
        "flushes": {"mu": 0.0},
        "nobs": {"mu": 0.027261}
      }
    }
  }
}
```

For same-rank pairs, the new artifact adds point-type details but no starter-suit relation bucket. For example, `5_5_Unsuited` dealer crib with starter `5` has `points`, but no `starter_suit_relation`, because same-rank discards are always treated as unsuited.

The numeric examples above are shape examples, not EV comparisons: the current release artifact uses production-scale samples, while the PR artifact shown here comes from the 300-sample pull-request workflow.

## How to Compare Locally

Compare one artifact from `main` with one artifact from this PR branch. The two runs should use the same seed, sample count, bootstrap settings, and control-variates setting. The PR-sized GitHub Actions run uses these settings:

- analytical bootstrap: `--max-iterations=2 --full-hand-policy-max-iterations=1`
- table generation: `--samples=300 --max-generations=1 --seed=42 --use-control-variates`

To generate a baseline from `main`, check out `main` in any clean worktree and run:

```sh
python artifact_pipeline/analytical_solver.py \
  --max-iterations=2 \
  --full-hand-policy-max-iterations=1 \
  --output expected_crib_points.analytical.json

python artifact_pipeline/generate_table.py \
  --bootstrap expected_crib_points.analytical.json \
  --samples 300 \
  --max-generations 1 \
  --output expected_crib_points.main.json \
  --no-resume \
  --seed 42 \
  --use-control-variates
```

For the PR-side file, either download the `expected-crib-points` artifact from the latest PR `Generate Crib Artifact` workflow run, or check out this PR branch and run the same two commands with `--output expected_crib_points.pr.json`.

Then compare the files with your preferred diff tool. A few useful command-line checks are:

```sh
python -m json.tool expected_crib_points.main.json > main.pretty.json
python -m json.tool expected_crib_points.pr.json > pr.pretty.json
wc -c expected_crib_points.main.json expected_crib_points.pr.json
gzip -c expected_crib_points.main.json | wc -c
gzip -c expected_crib_points.pr.json | wc -c
git diff --no-index main.pretty.json pr.pretty.json
```

What to look for:

- Both files should keep the same 169 top-level discard keys.
- The PR file should still have root `mu`, `se`, and `n` values for existing consumers.
- The PR file should add nested point-type details under `points`.
- The PR file should add `starter_suit_relation` buckets for suited different-rank discards.
- Same-rank pair discards should remain unsuited and should not gain suited relation buckets.

## Runtime and Size Impact

Measured with 300 samples, the same seed/bootstrap/control-variates command, and v1 run from `main`'s old `generate_table.py` via `PYTHONPATH`:

- v1 baseline: `real 41.68s`, raw JSON `1,202,946` bytes, gzipped `178,013` bytes.
- v2 current: `real 65.14s`, raw JSON `11,897,563` bytes, gzipped `1,564,150` bytes.

That isolated table-generation benchmark is about 1.56x slower. With the latest production baseline of 4h43m for 32,000 samples on `main`, leaving production generation at 32,000 samples would estimate to roughly 7h20m and risk the 6h GitHub Actions timeout.

This PR now reduces only the scheduled/manual production table generation target from 32,000 to 24,000 samples:

- Estimated production runtime: `4h43m * 1.56 * (24,000 / 32,000)`, or about 5h31m.
- Precision tradeoff: standard error scales as `sqrt(32,000 / 24,000)`, so the released table should have about 15.5% higher standard errors than the old 32,000-sample target.
- A 26,000-sample target would estimate around 5h59m, which is too close to the 6h Actions cap to leave useful runner-variance margin.
- PR generation remains at 300 samples; the latest PR `generate-table` job completed in about 3m41s, which is still reasonable for review feedback.

The increase comes from collecting the additional point-type and starter-suit relation accumulators during the existing simulation pass rather than adding extra samples.

## Validation

Passed locally:

- `coverage run -m unittest artifact_pipeline.test_adapter artifact_pipeline.test_generate_table artifact_pipeline.test_summarize_table`
- `coverage run`
- `coverage xml`
- `coverage report`
- `coverage run -m unittest discover artifact_pipeline`
- `coverage run --append scripts/run_slow_analytical_tests.py`
- `coverage report --fail-under=100 -m --include='artifact_pipeline/*'`
- `mypy simulate_cribbage_games.py artifact_pipeline`
- `npm run spellcheck`
- `pylint --persistent=n artifact_pipeline`
- `pylint --persistent=n --disable=all --enable=duplicate-code simulate_cribbage_games.py`
- `flake8`
- `git diff --check`
- `python artifact_pipeline/generate_table.py --bootstrap expected_crib_points.analytical.json --samples 5 --max-generations 1 --output /tmp/expected_crib_points.v2.json --no-resume --seed 42 --use-control-variates`
- `python artifact_pipeline/summarize_table.py /tmp/expected_crib_points.v2.json --role both`

Caveat:

- `pylint simulate_cribbage_games.py` still fails on existing immutable legacy warnings in `simulate_cribbage_games.py`; rerunning with `PYLINTHOME=/tmp/pylint-home` removed cache permission noise but left the same legacy warnings. I did not edit the immutable legacy file.
