### PR TITLE
ci: reduce production artifact generation samples

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Bounded because the analytical bootstrap is already converged. The
       # expanded artifact is about 1.56x slower locally; 16k samples keeps the
-      # production run comfortably below the 6h Actions limit (~3.4h runtime).
+      # production run comfortably below the 6h Actions limit (~5.2h runtime).
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -53,12 +53,12 @@ jobs:
           python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=300 --max-generations=1 --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       # Bounded because the analytical bootstrap is already converged. The
-      # expanded artifact is about 1.56x slower locally; 24k samples keeps the
-      # historical 4h43m production run comfortably below the 6h Actions limit.
+      # expanded artifact is about 1.56x slower locally; 16k samples keeps the
+      # production run comfortably below the 6h Actions limit (~3.4h runtime).
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=24000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=16000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
### Summary
This PR reduces the production table generation samples parameter in GHA from 24,000 to 16,000 to prevent runner timeouts caused by the 1.56x runtime overhead introduced by expanded v2 stats.

### Validation Done
- Ran  and  locally (no errors)
- Ran 
> simulate-cribbage-games@0.0.3 spellcheck
> cspell --config cspell.json locally (no errors)
- Ran unittest suite locally (all tests passed with 100% coverage on new files/methods)