### PR TITLE
Raise production crib artifact samples

### DIFF
--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -52,13 +52,13 @@ jobs:
         run: |
           python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=300 --max-generations=1 --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
-      # Bounded because the analytical bootstrap is already converged. The
-      # expanded artifact is about 1.56x slower locally; 16k samples keeps the
-      # production run comfortably below the 6h Actions limit (~5.2h runtime).
+      # Bounded because the analytical bootstrap is already converged. A 16k
+      # production run completed in 3h32m; 24k samples extrapolates to about
+      # 5h16m, leaving margin below the 6h Actions limit.
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=16000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=24000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/generate-crib-artifact.yml
+++ b/.github/workflows/generate-crib-artifact.yml
@@ -53,12 +53,12 @@ jobs:
           python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=300 --max-generations=1 --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       # Bounded because the analytical bootstrap is already converged. A 16k
-      # production run completed in 3h32m; 24k samples extrapolates to about
-      # 5h16m, leaving margin below the 6h Actions limit.
+      # production run completed in 3h32m; 22k samples extrapolates to about
+      # 4h50m, leaving roughly 70m below the 6h Actions limit.
       - name: Run production table generation
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=24000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
+          python -u artifact_pipeline/generate_table.py --bootstrap=expected_crib_points.analytical.json --samples=22000 --convergence-threshold=0.10 --max-generations=2 --fail-on-non-convergence --output=expected_crib_points.json --no-resume --seed=42 --use-control-variates
 
       - name: Upload analytical bootstrap artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
PR body drafted by OpenAI Codex.

## Summary

Raise scheduled/manual production expected-crib-points generation from 16,000 to 22,000 samples.

The merged v2 production path completed a 16k run in 3h32m17s, with 3h27m14s spent in table generation and 5m03s in overhead. Scaling the table-generation portion linearly gives an estimated 22k total runtime of about 4h50m, leaving roughly 70 minutes below the 6h GitHub Actions limit. This keeps substantially more runner-variance headroom than the earlier 24k target while still reducing standard error versus 16k.

## Validation

- git diff --check
- npm run spellcheck
- commit and pre-push hooks passed