### PR TITLE
fix: calculate matching_rank_1_suit and matching_rank_2_suit for unsuited discards

### DIFF
--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -43,7 +43,7 @@ from artifact_pipeline.adapter import (  # noqa: E402
 DEFAULT_OUTPUT_PATH = "expected_crib_points.json"
 DEFAULT_CHECKPOINT_FREQUENCY = 100
 METADATA_KEY = "__metadata__"
-GENERATION_METHOD = "artifact_pipeline.generate_table.v2"
+GENERATION_METHOD = "artifact_pipeline.generate_table.v3"
 POINT_TYPES = ("total", "fifteens", "pairs", "runs", "flushes", "nobs")
 MATCHING_DISCARD_SUIT = "matching_discard_suit"
 NON_MATCHING_DISCARD_SUIT = "non_matching_discard_suit"
@@ -817,6 +817,8 @@ def _run_mc_sample(
     relation = starter_suit_relation(canonical_pair, cut_card)
     if relation is not None:
         update_relation_accumulator(accumulator, relation, breakdown)
+    else:
+        pass  # pragma: no cover
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/artifact_pipeline/generate_table.py
+++ b/artifact_pipeline/generate_table.py
@@ -47,6 +47,8 @@ GENERATION_METHOD = "artifact_pipeline.generate_table.v2"
 POINT_TYPES = ("total", "fifteens", "pairs", "runs", "flushes", "nobs")
 MATCHING_DISCARD_SUIT = "matching_discard_suit"
 NON_MATCHING_DISCARD_SUIT = "non_matching_discard_suit"
+MATCHING_RANK_1_SUIT = "matching_rank_1_suit"
+MATCHING_RANK_2_SUIT = "matching_rank_2_suit"
 ROOT_ACCUMULATOR_KEYS = (
     "n",
     "sum",
@@ -597,9 +599,22 @@ def average_breakdowns(breakdowns):
 
 def starter_suit_relation(canonical_pair, starter):
     parts = canonical_pair.split("_")
-    if parts[0] == parts[1] or parts[2] != "Suited":
-        return None
-    return MATCHING_DISCARD_SUIT if starter.suit == 0 else NON_MATCHING_DISCARD_SUIT
+    if parts[2] == "Suited":
+        return MATCHING_DISCARD_SUIT if starter.suit == 0 else NON_MATCHING_DISCARD_SUIT
+
+    if parts[0] == parts[1]:
+        # Pair
+        return (
+            MATCHING_DISCARD_SUIT
+            if starter.suit in (0, 1)
+            else NON_MATCHING_DISCARD_SUIT
+        )
+
+    if starter.suit == 0:
+        return MATCHING_RANK_1_SUIT
+    if starter.suit == 1:
+        return MATCHING_RANK_2_SUIT
+    return NON_MATCHING_DISCARD_SUIT
 
 
 def average_starter_breakdowns(starter_breakdowns):
@@ -608,7 +623,18 @@ def average_starter_breakdowns(starter_breakdowns):
 
 def relation_breakdowns_for_starters(canonical_pair, starter_breakdowns):
     relation_breakdowns = {}
-    for relation in (MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT):
+
+    parts = canonical_pair.split("_")
+    if parts[2] == "Suited" or parts[0] == parts[1]:
+        relations = (MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT)
+    else:
+        relations = (
+            MATCHING_RANK_1_SUIT,
+            MATCHING_RANK_2_SUIT,
+            NON_MATCHING_DISCARD_SUIT,
+        )
+
+    for relation in relations:
         breakdowns = [
             breakdown
             for starter, breakdown in starter_breakdowns

--- a/artifact_pipeline/test_generate_table.py
+++ b/artifact_pipeline/test_generate_table.py
@@ -49,6 +49,8 @@ from artifact_pipeline.generate_table import (
     POINT_TYPES,
     MATCHING_DISCARD_SUIT,
     NON_MATCHING_DISCARD_SUIT,
+    MATCHING_RANK_1_SUIT,
+    MATCHING_RANK_2_SUIT,
 )
 from artifact_pipeline.adapter import (
     Card,
@@ -361,7 +363,7 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         )
         self.assertAlmostEqual(component_total, bucket["points"]["total"]["mu"])
 
-    def test_same_rank_pair_has_no_starter_suit_relation(self):
+    def test_same_rank_pair_has_starter_suit_relation(self):
         accumulators = {}
         run_monte_carlo_into_accumulators(
             accumulators,
@@ -379,8 +381,55 @@ class TestGenerateTable(unittest.TestCase):  # pylint: disable=too-many-public-m
         output = accumulators_to_output(accumulators, pairs=["A_A_Unsuited"])
 
         self.assertNotIn("A_A_Suited", output)
+        all_relations = set()
         for bucket in output["A_A_Unsuited"]["Dealer"].values():
-            self.assertNotIn("starter_suit_relation", bucket)
+            if "starter_suit_relation" in bucket:
+                bucket_relations = set(bucket["starter_suit_relation"].keys())
+                self.assertTrue(
+                    bucket_relations.issubset(
+                        {MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT}
+                    )
+                )
+                all_relations.update(bucket_relations)
+        self.assertEqual(
+            all_relations, {MATCHING_DISCARD_SUIT, NON_MATCHING_DISCARD_SUIT}
+        )
+
+    def test_unsuited_discard_has_starter_suit_relation(self):
+        accumulators = {}
+        run_monte_carlo_into_accumulators(
+            accumulators,
+            "A_2_Unsuited",
+            "Dealer",
+            1,
+            {
+                "rng": random.Random(42),
+                "first_sample_index": 0,
+                "seed": 42,
+                "use_control_variates": True,
+            },
+        )
+
+        output = accumulators_to_output(accumulators, pairs=["A_2_Unsuited"])
+
+        all_relations = set()
+        for bucket in output["A_2_Unsuited"]["Dealer"].values():
+            if "starter_suit_relation" in bucket:
+                bucket_relations = set(bucket["starter_suit_relation"].keys())
+                self.assertTrue(
+                    bucket_relations.issubset(
+                        {
+                            MATCHING_RANK_1_SUIT,
+                            MATCHING_RANK_2_SUIT,
+                            NON_MATCHING_DISCARD_SUIT,
+                        }
+                    )
+                )
+                all_relations.update(bucket_relations)
+        self.assertEqual(
+            all_relations,
+            {MATCHING_RANK_1_SUIT, MATCHING_RANK_2_SUIT, NON_MATCHING_DISCARD_SUIT},
+        )
 
     def test_suited_pair_has_matching_and_non_matching_starter_buckets(self):
         accumulators = {}


### PR DESCRIPTION
Updates EV bucket calculation logic to support granular unsuited discard starter suit relations for the trainer UI.