### PR TITLE
feat: emit play-table sampling progress heartbeat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,6 +371,11 @@ per-entry standard error is about 2.7 / sqrt(samples), near 0.024. The emitted
 artifact records `joint_policy_converged: false`; that is expected for the
 capped run and is not a failure.
 
+Each sampling pass (the per-outer policy tables and the final pass) emits a
+progress heartbeat to stderr -- a start line plus `hand X/Y` lines at every
+checkpoint with elapsed, remaining, and median standard error -- so a long run
+is observable rather than silent. The rollout-IBR training phases stay quiet.
+
 Raising `--samples` tightens the SE (and `--ibr-samples` improves policy quality
 at a fixed setup cost): about 16,000 samples still finishes under the cap at the
 paranoid 2.5x. Beyond that -- for example a tight `--target-standard-error=0.02`

--- a/artifact_pipeline/generate_play_table.py
+++ b/artifact_pipeline/generate_play_table.py
@@ -11,9 +11,11 @@ import math
 import os
 import random
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial
+from statistics import median
 from typing import Any, Mapping, Sequence
 
 if __package__ in (None, ""):  # pragma: no cover
@@ -272,6 +274,44 @@ def _sample_seed(entry_seed: int, sample_index: int) -> int:
     return entry_seed + sample_index * 3_640_003
 
 
+def _format_duration(seconds: float) -> str:
+    """Render an elapsed or remaining duration as Hh MMm or MMmSSs."""
+    minutes, secs = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    return f"{minutes}m{secs:02d}s"
+
+
+def _maybe_checkpoint(
+    checkpoint: Callable[[Mapping[str, Any]], None] | None,
+    output: Mapping[str, Any],
+) -> None:
+    """Persist the in-progress table when a checkpoint callback is configured."""
+    if checkpoint is not None:
+        checkpoint(output)
+
+
+def _log_progress(
+    completed_hands: int,
+    total_hands: int,
+    start_time: float,
+    entry_standard_errors: Sequence[float],
+) -> None:
+    """Emit a one-line sampling heartbeat to stderr for the long sampling pass."""
+    elapsed = time.monotonic() - start_time
+    fraction = completed_hands / total_hands
+    remaining = elapsed / fraction - elapsed
+    print(
+        f"[play-table] hand {completed_hands}/{total_hands} "
+        f"({fraction * 100:.0f}%) - elapsed {_format_duration(elapsed)} - "
+        f"remaining ~{_format_duration(remaining)} - median standard error "
+        f"{median(entry_standard_errors):.4f}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def validate_resume_table(
     existing_table: Mapping[str, Any],
     seed: int,
@@ -338,6 +378,15 @@ def generate_play_table(
             "policy_fingerprint": play_policy_fingerprint,
         },
     }
+    total_hands = len(requested_hands)
+    start_time = time.monotonic()
+    completed_entry_standard_errors: list[float] = []
+    print(
+        f"[play-table] sampling {total_hands} hands x {len(ROLES)} roles "
+        f"x up to {max_samples or samples} samples",
+        file=sys.stderr,
+        flush=True,
+    )
     for hand_index, hand in enumerate(requested_hands):
         hand_key = canonical_hand_key(hand)
         role_entries = output.setdefault(hand_key, {})
@@ -370,11 +419,18 @@ def generate_play_table(
                 if accumulators.delta.n >= samples and target_standard_error is None:
                     break
             role_entries[target_role] = _entry_to_output(accumulators)
-        if checkpoint is not None and (
-            (hand_index + 1) % checkpoint_frequency == 0
-            or hand_index + 1 == len(requested_hands)
-        ):
-            checkpoint(output)
+            completed_entry_standard_errors.append(accumulators.delta.standard_error)
+        at_checkpoint = (hand_index + 1) % checkpoint_frequency == 0 or (
+            hand_index + 1 == total_hands
+        )
+        if at_checkpoint:
+            _maybe_checkpoint(checkpoint, output)
+            _log_progress(
+                hand_index + 1,
+                total_hands,
+                start_time,
+                completed_entry_standard_errors,
+            )
     return output
 
 

--- a/artifact_pipeline/test_generate_play_table.py
+++ b/artifact_pipeline/test_generate_play_table.py
@@ -1,6 +1,7 @@
 """Tests for expected pegging artifact generation."""
 
 import argparse
+import io
 import itertools
 import json
 import math
@@ -17,6 +18,7 @@ from artifact_pipeline.generate_play_table import (
     DEFAULT_OUTPUT_PATH,
     DiscardPolicy,
     PONE,
+    _format_duration,
     _parse_args,
     _representative_physical_hand,
     _sample_target_deal,
@@ -213,6 +215,25 @@ class TestGeneratePlayTable(unittest.TestCase):
         for hand in (first_hand, second_hand):
             hand_key = canonical_hand_key(hand)
             self.assertEqual(forward[hand_key], reversed_order[hand_key])
+
+    def test_format_duration_handles_hours_and_minutes(self):
+        self.assertEqual(_format_duration(65), "1m05s")
+        self.assertEqual(_format_duration(3725), "1h02m")
+
+    def test_sampling_emits_progress_heartbeat_to_stderr(self):
+        stderr = io.StringIO()
+        with patch("sys.stderr", stderr):
+            generate_play_table(
+                self.discard_policy,
+                self.play_policies,
+                samples=2,
+                seed=42,
+                hands=[(0, 1, 2, 3), (1, 2, 3, 4)],
+            )
+        report = stderr.getvalue()
+        self.assertTrue("[play-table] sampling 2 hands" in report)
+        self.assertTrue("[play-table] hand 2/2 (100%)" in report)
+        self.assertTrue("median standard error" in report)
 
     def test_adaptive_sampling_and_generation_validation(self):
         table = generate_play_table(


### PR DESCRIPTION
## Summary

`generate_play_table.py` went silent for the entire rollout-IBR and Monte Carlo sampling phase — roughly 90% of a production run. During the 2026-06-27 run the log had no output for ~2 hours, making progress indistinguishable from a hang.

This emits a lightweight progress heartbeat to **stderr** from the sampling loop:

- a start line per sampling pass: `[play-table] sampling 1820 hands x 2 roles x up to 13000 samples`
- a line at each checkpoint boundary: `[play-table] hand 600/1820 (33%) - elapsed 1h02m - remaining ~1h18m - median standard error 0.0412`

It is decoupled from the checkpoint callback, so the per-outer policy-table passes are covered too, not just the final pass. Rollout-IBR training (in `pegging.py`) stays quiet — out of scope here. **stderr only**, so artifact contents are unchanged.

Live bounded smoke (`--hand-limit=4`):

```
[play-table] sampling 4 hands x 2 roles x up to 10 samples
[play-table] hand 4/4 (100%) - elapsed 0m00s - remaining ~0m00s - median standard error 0.7763
[play-table] sampling 4 hands x 2 roles x up to 25 samples
[play-table] hand 4/4 (100%) - elapsed 0m00s - remaining ~0m00s - median standard error 0.5354
```

## Notes

Adding the heartbeat tipped the core loop one over pylint's `too-many-branches` limit, so the checkpoint guard is extracted into a small `_maybe_checkpoint` helper (which also reads cleaner) rather than suppressing the check.

## Validation

black, flake8, pylint 10.00/10, mypy, cspell; full `artifact_pipeline` suite (201 tests) green; 100% coverage retained (new `_format_duration` unit-tested both branches, heartbeat verified via captured stderr).

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)