### PR TITLE
docs: require learnings capture in every PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,13 @@ Before opening or updating a pull request, summarize what changed, why it
 changed, and which validation commands were run. Include any skipped checks and
 the reason they were skipped.
 
+Every pull request must also capture the session's durable, non-obvious
+learnings — new invariants, debugging techniques, validation pitfalls, or
+review-workflow quirks discovered while doing the work — in `AGENTS.md` or the
+matching `skills/` document as part of the same pull request, not as a
+follow-up. If the work produced no such learnings, say so explicitly in the
+pull request description.
+
 Use local `git` as the source of truth for branch, commit, and push state before
 creating a pull request. After pushing, verify that the remote branch exists and
 record the pull request URL. If one GitHub integration cannot create the pull


### PR DESCRIPTION
Claude Code (Fable 5, medium effort) agent:

## Summary

Adds a Pull Request Readiness paragraph requiring every coding session — regardless of agent — to capture its durable, non-obvious learnings (new invariants, debugging techniques, validation pitfalls, review-workflow quirks) in AGENTS.md or the matching skills/ document within the same pull request as the code change, and to state explicitly in the PR description when the work produced no such learnings.

Requested by the maintainer so Claude, Codex, and other agents keep the repository contract improving instead of relying on per-session memory. The same policy was proposed for cribbage-trainer in markafitzgerald1/cribbage-trainer#659.

## Validation

Documentation-only change. Checks run: npm run spellcheck (24 files, 0 issues) and the full pre-commit hook suite on commit (all hooks passed, including cspell and codespell). Expensive code validation was skipped because no executable behavior changed.

No learnings beyond the policy itself arose from this documentation-only change.