### PR TITLE
Analyze expected opponent hand points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,12 +347,17 @@ Expected opponent hand points conditional on a user's known six-card deal are
 invariant across that user's 15 discard choices: all six known cards are removed
 from the opponent-deal and starter populations regardless of which two enter the
 crib, and a hidden-information opponent cannot condition on the selected
-discard. Such a value can clarify presentation but cannot change discard
-rankings. Suit-aware research may canonicalize physical deals under all 24
+discard. Adding that value linearly to the current position-unaware objective
+cannot change discard rankings. It can still inform a nonlinear board-position
+policy, where the likely opponent score affects offensive, defensive, and
+variance choices. Before publishing an artifact, determine whether that policy
+needs the opponent mean, a score distribution, tail probabilities, or joint
+outcomes. Suit-aware research may canonicalize physical deals under all 24
 global suit permutations, provided rank-to-suit incidence is preserved; this
 reduces the six-card state space to 962,988 entries but does not by itself make
-JSON browser-friendly. Keep this research producer-side and require a separate
-precision and consumer-contract decision before publishing an artifact.
+JSON browser-friendly. Start positional experiments with the compact exact rank
+model, keep expensive calculation producer-side, and require a separate
+precision and consumer-contract decision before suit-aware publication.
 
 Seeded play-table samples are independent by canonical hand, role, and
 cumulative sample index. Preserve this property when changing generation or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,17 @@ client artifact recursively strips `n` and `se` while retaining those means.
 Do not expose hidden opponent cards to policy inputs or move rollout decisions
 into the browser.
 
+Expected opponent hand points conditional on a user's known six-card deal are
+invariant across that user's 15 discard choices: all six known cards are removed
+from the opponent-deal and starter populations regardless of which two enter the
+crib, and a hidden-information opponent cannot condition on the selected
+discard. Such a value can clarify presentation but cannot change discard
+rankings. Suit-aware research may canonicalize physical deals under all 24
+global suit permutations, provided rank-to-suit incidence is preserved; this
+reduces the six-card state space to 962,988 entries but does not by itself make
+JSON browser-friendly. Keep this research producer-side and require a separate
+precision and consumer-contract decision before publishing an artifact.
+
 Seeded play-table samples are independent by canonical hand, role, and
 cumulative sample index. Preserve this property when changing generation or
 checkpoint behavior so resumed runs remain equivalent to uninterrupted runs.

--- a/README.md
+++ b/README.md
@@ -279,6 +279,23 @@ diverge grossly from the reference. Only a small representative sample is kept,
 re-expressed in this project's keys with a no-copyright-claim note on the
 underlying averages.
 
+### Expected opponent hand points research
+
+Issue #75's research command compares exact suitless conditional opponent hand
+values with a suit-aware physical-card sampling pilot:
+
+```sh
+python artifact_pipeline/analyze_opponent_hand_points.py \
+  --physical-samples=10000 \
+  --seed=42 \
+  --output=opponent_hand_points_analysis.json
+```
+
+See
+[docs/expected-opponent-hand-points-spike.md](docs/expected-opponent-hand-points-spike.md)
+for the model, measurements, artifact-size analysis, and recommendation. This
+command emits research data only; it does not publish a browser artifact.
+
 Summarize a generated table:
 
 ```sh

--- a/artifact_pipeline/analyze_opponent_hand_points.py
+++ b/artifact_pipeline/analyze_opponent_hand_points.py
@@ -1,0 +1,551 @@
+"""Analyze conditional opponent hand points for issue 75."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+import gzip
+import hashlib
+import itertools
+import json
+import math
+import random
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+if __package__ in (None, ""):  # pragma: no cover
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# pylint: disable=wrong-import-position
+from artifact_pipeline.adapter import Card, Index, score_hand_and_starter_breakdown
+from artifact_pipeline.analytical_solver import (
+    DEFAULT_FULL_HAND_POLICY_MAX_ITERATIONS,
+    DEFAULT_IBR_MAX_ITERATIONS,
+    _iter_containment_subset_weights,
+    _iter_rank_count_subsets,
+    get_hand_combinations_with_weights,
+    score_combination_suit_free,
+)
+from artifact_pipeline.generate_play_table import (
+    DEALER,
+    PONE,
+    ROLES,
+    DiscardPolicy,
+    selected_discards_to_policy,
+    solve_initial_discard_policy,
+)
+
+PHYSICAL_DECK = tuple((rank, suit) for rank in range(13) for suit in range(4))
+DEFAULT_SEED = 42
+DEFAULT_PHYSICAL_SAMPLES = 10_000
+PHYSICAL_SIX_CARD_DEALS = math.comb(52, 6)
+CONDITIONED_OPPONENT_DEALS = math.comb(46, 6)
+STARTERS_PER_DEAL = 40
+FLOAT32_BYTES = 4
+INT16_BYTES = 2
+
+
+@dataclass
+class PolicySubsetAggregate:
+    """Policy scoring totals for opponent deals containing a fixed subset."""
+
+    weight: int = 0
+    role_base_totals: dict[str, float] = field(
+        default_factory=lambda: {PONE: 0.0, DEALER: 0.0}
+    )
+    role_starter_scores: dict[str, list[float]] = field(
+        default_factory=lambda: {PONE: [0.0] * 13, DEALER: [0.0] * 13}
+    )
+
+
+@dataclass
+class SampleMoments:
+    """Streaming physical-card sample moments."""
+
+    n: int = 0
+    mean: float = 0.0
+    moment_2: float = 0.0
+
+    def add(self, value: float) -> None:
+        """Add one sampled score."""
+        self.n += 1
+        delta = value - self.mean
+        self.mean += delta / self.n
+        self.moment_2 += delta * (value - self.mean)
+
+    @property
+    def standard_deviation(self) -> float:
+        """Return the sample standard deviation."""
+        if self.n < 2:
+            return 0.0
+        return math.sqrt(self.moment_2 / (self.n - 1))
+
+    @property
+    def standard_error(self) -> float:
+        """Return the standard error of the sampled mean."""
+        if not self.n:
+            return math.inf
+        return self.standard_deviation / math.sqrt(self.n)
+
+
+REPRESENTATIVE_PHYSICAL_DEALS: tuple[tuple[str, tuple[tuple[int, int], ...]], ...] = (
+    ("six_one_suit", tuple((rank, 0) for rank in range(6))),
+    (
+        "four_two_suits",
+        ((0, 0), (1, 0), (2, 0), (3, 0), (4, 1), (5, 1)),
+    ),
+    (
+        "three_three_suits",
+        ((3, 0), (4, 0), (5, 0), (6, 1), (7, 1), (8, 1)),
+    ),
+    (
+        "two_two_two_suits",
+        ((7, 0), (8, 0), (9, 1), (10, 1), (11, 2), (12, 2)),
+    ),
+    (
+        "paired_ranks_mixed_suits",
+        ((0, 0), (0, 1), (4, 0), (4, 2), (10, 3), (12, 1)),
+    ),
+    (
+        "triple_rank_mixed_suits",
+        ((5, 0), (5, 1), (5, 2), (8, 0), (10, 1), (12, 3)),
+    ),
+)
+
+
+def positive_int(value: str) -> int:
+    """Parse a strictly positive integer."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def nonnegative_int(value: str) -> int:
+    """Parse a nonnegative integer."""
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def canonical_suit_key(cards: Iterable[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
+    """Return the lexicographically smallest global-suit permutation."""
+    sorted_cards = tuple(sorted(cards))
+    if len(set(sorted_cards)) != len(sorted_cards):
+        raise ValueError("physical cards must be unique")
+    if any(
+        rank not in range(13) or suit not in range(4) for rank, suit in sorted_cards
+    ):
+        raise ValueError("physical cards must use ranks 0..12 and suits 0..3")
+    return min(
+        tuple(sorted((rank, permutation[suit]) for rank, suit in sorted_cards))
+        for permutation in itertools.permutations(range(4))
+    )
+
+
+def suit_normalized_six_card_state_count() -> int:
+    """Count physical six-card deals modulo global suit renaming."""
+    identity_fixed = math.comb(52, 6)
+    transposition_fixed = sum(
+        math.comb(13, paired) * math.comb(26, 6 - 2 * paired) for paired in range(4)
+    )
+    double_transposition_fixed = math.comb(26, 3)
+    three_cycle_fixed = sum(
+        math.comb(13, triples) * math.comb(13, 6 - 3 * triples) for triples in range(3)
+    )
+    four_cycle_fixed = 0
+    fixed_sum = (
+        identity_fixed
+        + 6 * transposition_fixed
+        + 3 * double_transposition_fixed
+        + 8 * three_cycle_fixed
+        + 6 * four_cycle_fixed
+    )
+    return fixed_sum // math.factorial(4)
+
+
+def _rank_counts(hand: Sequence[int]) -> tuple[tuple[int, int], ...]:
+    return tuple((rank, hand.count(rank)) for rank in sorted(set(hand)))
+
+
+def _kept_scores(
+    policy: DiscardPolicy, role: str, hand: Sequence[int]
+) -> tuple[float, ...]:
+    kept = policy.kept_ranks(role, hand)
+    return tuple(score_combination_suit_free(kept, rank) for rank in range(13))
+
+
+def build_policy_subset_aggregates(
+    policy: DiscardPolicy,
+    hands: Sequence[tuple[tuple[int, ...], int]],
+) -> dict[tuple[tuple[int, int], ...], PolicySubsetAggregate]:
+    """Aggregate exact rank-policy scores for fast six-card conditioning."""
+    aggregates: dict[tuple[tuple[int, int], ...], PolicySubsetAggregate] = {}
+    for hand, _physical_weight in hands:
+        rank_counts = _rank_counts(hand)
+        role_scores = {role: _kept_scores(policy, role, hand) for role in ROLES}
+        role_base_totals = {
+            role: 4.0 * sum(scores) - sum(scores[rank] for rank in hand)
+            for role, scores in role_scores.items()
+        }
+        for subset_key, completion_weight in _iter_containment_subset_weights(
+            rank_counts
+        ):
+            aggregate = aggregates.setdefault(subset_key, PolicySubsetAggregate())
+            aggregate.weight += completion_weight
+            for role in ROLES:
+                aggregate.role_base_totals[role] += (
+                    completion_weight * role_base_totals[role]
+                )
+                for rank, score in enumerate(role_scores[role]):
+                    aggregate.role_starter_scores[role][rank] += (
+                        completion_weight * score
+                    )
+    return aggregates
+
+
+def conditioned_suitless_expected_values(
+    known_hand: Sequence[int],
+    aggregates: Mapping[tuple[tuple[int, int], ...], PolicySubsetAggregate],
+) -> dict[str, float]:
+    """Return exact suitless opponent hand EVs after removing a known six."""
+    known_counts = _rank_counts(known_hand)
+    conditioned_weight = 0
+    role_totals = {PONE: 0.0, DEALER: 0.0}
+    for subset_key, subset_size, multiplicity in _iter_rank_count_subsets(known_counts):
+        aggregate = aggregates[subset_key]
+        coefficient = -multiplicity if subset_size % 2 else multiplicity
+        conditioned_weight += coefficient * aggregate.weight
+        for role in ROLES:
+            removed_starter_total = sum(
+                count * aggregate.role_starter_scores[role][rank]
+                for rank, count in known_counts
+            )
+            role_totals[role] += coefficient * (
+                aggregate.role_base_totals[role] - removed_starter_total
+            )
+    if conditioned_weight != CONDITIONED_OPPONENT_DEALS:
+        raise ValueError(
+            "conditioned opponent deal count was "
+            f"{conditioned_weight}, expected {CONDITIONED_OPPONENT_DEALS}"
+        )
+    denominator = conditioned_weight * STARTERS_PER_DEAL
+    return {role: role_totals[role] / denominator for role in ROLES}
+
+
+def exact_suitless_table(
+    policy: DiscardPolicy, hand_limit: int | None = None
+) -> dict[str, dict[str, float]]:
+    """Generate exact rank-only values for every requested known six-card hand."""
+    hands = get_hand_combinations_with_weights()
+    aggregates = build_policy_subset_aggregates(policy, hands)
+    selected_hands = hands[:hand_limit] if hand_limit is not None else hands
+    return {
+        rank_hand_key(hand): conditioned_suitless_expected_values(hand, aggregates)
+        for hand, _weight in selected_hands
+    }
+
+
+def rank_hand_key(hand: Sequence[int]) -> str:
+    """Format a sorted rank hand as a stable artifact-sizing key."""
+    return "_".join(Index.indices[rank] for rank in hand)
+
+
+def _physical_sample_seed(seed: int, deal_name: str, role: str) -> int:
+    payload = f"{seed}|{deal_name}|{role}".encode("ascii")
+    return int.from_bytes(hashlib.sha256(payload).digest()[:16], "big")
+
+
+def _sample_rank_policy_keep(
+    policy: DiscardPolicy,
+    role: str,
+    dealt_cards: Sequence[tuple[int, int]],
+    rng: random.Random,
+) -> tuple[tuple[int, int], ...]:
+    """Apply a rank policy with unbiased suit selection for rank-equivalent cards."""
+    kept_ranks = policy.kept_ranks(role, sorted(card[0] for card in dealt_cards))
+    needed = {rank: kept_ranks.count(rank) for rank in set(kept_ranks)}
+    kept = []
+    for rank, count in needed.items():
+        candidates = [card for card in dealt_cards if card[0] == rank]
+        kept.extend(rng.sample(candidates, count))
+    return tuple(sorted(kept))
+
+
+def sample_suit_aware_hand_points(
+    known_deal: Sequence[tuple[int, int]],
+    opponent_role: str,
+    policy: DiscardPolicy,
+    samples: int,
+    seed: int,
+) -> SampleMoments:
+    """Sample physical opponent hand points under the rank-driven policy."""
+    known = set(known_deal)
+    if len(known) != 6:
+        raise ValueError("known deal must contain six unique physical cards")
+    remaining = [card for card in PHYSICAL_DECK if card not in known]
+    rng = random.Random(seed)
+    moments = SampleMoments()
+    for _sample_index in range(samples):
+        opponent_dealt = rng.sample(remaining, 6)
+        kept = _sample_rank_policy_keep(policy, opponent_role, opponent_dealt, rng)
+        starter_pool = [card for card in remaining if card not in opponent_dealt]
+        starter = rng.choice(starter_pool)
+        score = score_hand_and_starter_breakdown(
+            [Card(rank, suit) for rank, suit in kept],
+            Card(*starter),
+        )["total"]
+        moments.add(float(score))
+    return moments
+
+
+def _role_summary(
+    table: Mapping[str, Mapping[str, float]], role: str
+) -> dict[str, float]:
+    values = [entry[role] for entry in table.values()]
+    return {
+        "minimum": min(values),
+        "maximum": max(values),
+        "mean": statistics.fmean(values),
+        "population_standard_deviation": statistics.pstdev(values),
+    }
+
+
+def _rank_table_sizes(table: Mapping[str, Mapping[str, float]]) -> dict[str, int]:
+    minified = json.dumps(table, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return {
+        "minified_json_bytes": len(minified),
+        "gzip_bytes": len(gzip.compress(minified, 9)),
+        "packed_float32_value_bytes": len(table) * len(ROLES) * FLOAT32_BYTES,
+    }
+
+
+def _normalized_size_projections(
+    rank_table: Mapping[str, Mapping[str, float]],
+    normalized_count: int,
+    physical_pilot: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, int | str]:
+    rank_sizes = _rank_table_sizes(rank_table)
+    rank_count = len(rank_table)
+    if physical_pilot:
+        physical_entries = {
+            entry["canonical_key"]: {
+                role: role_entry["mu"] for role, role_entry in entry["roles"].items()
+            }
+            for entry in physical_pilot
+        }
+        physical_json = json.dumps(
+            physical_entries, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        average_json_entry = len(physical_json) / len(physical_entries)
+        projection_basis = "representative physical pilot keys and values"
+    else:
+        average_json_entry = rank_sizes["minified_json_bytes"] / rank_count
+        projection_basis = "rank-table fallback because no physical pilot was run"
+    compression_ratio = rank_sizes["gzip_bytes"] / rank_sizes["minified_json_bytes"]
+    projected_json_bytes = round(average_json_entry * normalized_count)
+    return {
+        "json_projection_basis": projection_basis,
+        "projected_minified_json_bytes": projected_json_bytes,
+        "projected_gzip_bytes": round(projected_json_bytes * compression_ratio),
+        "packed_float32_value_bytes": normalized_count * len(ROLES) * FLOAT32_BYTES,
+        "quantized_int16_residual_bytes": normalized_count * len(ROLES) * INT16_BYTES,
+        "rank_float32_plus_quantized_residual_bytes": (
+            rank_count * len(ROLES) * FLOAT32_BYTES
+            + normalized_count * len(ROLES) * INT16_BYTES
+        ),
+    }
+
+
+def _runtime_projections(
+    pilot: Sequence[Mapping[str, Any]], elapsed_seconds: float
+) -> dict[str, Any]:
+    """Project normalized-table sampling runtime from the physical pilot."""
+    role_entries = [
+        role_entry
+        for deal_entry in pilot
+        for role_entry in deal_entry["roles"].values()
+    ]
+    if not role_entries or elapsed_seconds <= 0.0:
+        return {"observed_samples_per_second": None, "precision_targets": {}}
+    observed_samples = sum(entry["n"] for entry in role_entries)
+    samples_per_second = observed_samples / elapsed_seconds
+    maximum_standard_deviation = max(
+        entry["standard_deviation"] for entry in role_entries
+    )
+    normalized_count = suit_normalized_six_card_state_count()
+    targets = {}
+    for target_standard_error in (0.04, 0.02, 0.01):
+        samples_per_entry = math.ceil(
+            (maximum_standard_deviation / target_standard_error) ** 2
+        )
+        total_samples = samples_per_entry * normalized_count * len(ROLES)
+        targets[f"{target_standard_error:.2f}"] = {
+            "samples_per_entry": samples_per_entry,
+            "total_samples": total_samples,
+            "single_process_seconds": total_samples / samples_per_second,
+        }
+    return {
+        "observed_samples_per_second": samples_per_second,
+        "maximum_observed_standard_deviation": maximum_standard_deviation,
+        "precision_targets": targets,
+    }
+
+
+def analyze(  # pylint: disable=too-many-locals
+    policy: DiscardPolicy,
+    hand_limit: int | None,
+    physical_samples: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Run the exact rank analysis and the suit-aware sampling pilot."""
+    started = time.monotonic()
+    suitless_started = time.monotonic()
+    suitless_table = exact_suitless_table(policy, hand_limit=hand_limit)
+    suitless_seconds = time.monotonic() - suitless_started
+    normalized_count = suit_normalized_six_card_state_count()
+    pilot = []
+    pilot_started = time.monotonic()
+    if physical_samples:
+        for deal_name, known_deal in REPRESENTATIVE_PHYSICAL_DEALS:
+            rank_key = rank_hand_key(sorted(card[0] for card in known_deal))
+            if rank_key not in suitless_table:
+                continue
+            role_results = {}
+            for role in ROLES:
+                moments = sample_suit_aware_hand_points(
+                    known_deal,
+                    role,
+                    policy,
+                    physical_samples,
+                    _physical_sample_seed(seed, deal_name, role),
+                )
+                baseline = suitless_table[rank_key][role]
+                role_results[role] = {
+                    "n": moments.n,
+                    "mu": moments.mean,
+                    "standard_deviation": moments.standard_deviation,
+                    "standard_error": moments.standard_error,
+                    "suitless_mu": baseline,
+                    "suit_effect": moments.mean - baseline,
+                }
+            pilot.append(
+                {
+                    "name": deal_name,
+                    "canonical_key": physical_deal_key(canonical_suit_key(known_deal)),
+                    "rank_key": rank_key,
+                    "roles": role_results,
+                }
+            )
+    pilot_seconds = time.monotonic() - pilot_started
+    full_rank_state_count = len(get_hand_combinations_with_weights())
+    report = {
+        "model": {
+            "known_cards": 6,
+            "opponent_deal_population": 46,
+            "opponent_dealt_cards": 6,
+            "starter_population_after_both_deals": 40,
+            "opponent_policy": "role-specific analytical E(h +/- c) rank policy",
+            "suit_aware_policy_limit": (
+                "physical scoring with unbiased suits among rank-equivalent keeps; "
+                "discarded ranks remain policy-driven but suit-blind"
+            ),
+        },
+        "discard_invariance": {
+            "opponent_ev_varies_across_user_discards": False,
+            "discard_choices": math.comb(6, 2),
+            "reason": (
+                "the same six user cards are removed for every discard choice, and "
+                "the opponent cannot condition on the hidden selected discard"
+            ),
+        },
+        "state_counts": {
+            "physical_six_card_deals": PHYSICAL_SIX_CARD_DEALS,
+            "suit_normalized_six_card_states": normalized_count,
+            "suitless_rank_states": full_rank_state_count,
+            "analyzed_suitless_rank_states": len(suitless_table),
+            "exact_physical_outcomes_per_known_deal": (
+                CONDITIONED_OPPONENT_DEALS * STARTERS_PER_DEAL
+            ),
+        },
+        "suitless_exact": {
+            "sampling_variance": 0.0,
+            "roles": {role: _role_summary(suitless_table, role) for role in ROLES},
+            "artifact_sizes": _rank_table_sizes(suitless_table),
+            "elapsed_seconds": suitless_seconds,
+        },
+        "suit_aware_pilot": {
+            "samples_per_deal_and_role": physical_samples,
+            "deal_count": len(pilot),
+            "entries": pilot,
+            "elapsed_seconds": pilot_seconds,
+            "runtime_projections": _runtime_projections(pilot, pilot_seconds),
+            "normalized_artifact_size_projections": _normalized_size_projections(
+                suitless_table, normalized_count, pilot
+            ),
+        },
+        "recommendation": (
+            "defer a production opponent-hand artifact because its value is constant "
+            "across the user's discard choices; retain suit-normalized binary or "
+            "rank-baseline-plus-residual encoding as feasible presentation-only research"
+        ),
+        "elapsed_seconds": time.monotonic() - started,
+    }
+    return report
+
+
+def physical_deal_key(cards: Sequence[tuple[int, int]]) -> str:
+    """Format physical cards as a stable compact key."""
+    return "_".join(f"{Index.indices[rank]}{suit}" for rank, suit in cards)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--hand-limit", type=positive_int)
+    parser.add_argument(
+        "--physical-samples", type=nonnegative_int, default=DEFAULT_PHYSICAL_SAMPLES
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--analytical-max-iterations",
+        type=positive_int,
+        default=DEFAULT_IBR_MAX_ITERATIONS,
+    )
+    parser.add_argument(
+        "--full-hand-policy-max-iterations",
+        type=positive_int,
+        default=DEFAULT_FULL_HAND_POLICY_MAX_ITERATIONS,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the issue 75 analysis command."""
+    started = time.monotonic()
+    args = _parse_args(argv)
+    policy_started = time.monotonic()
+    context = solve_initial_discard_policy(
+        args.analytical_max_iterations,
+        args.full_hand_policy_max_iterations,
+    )
+    policy_seconds = time.monotonic() - policy_started
+    policy = selected_discards_to_policy(context.selected_discards)
+    report = analyze(policy, args.hand_limit, args.physical_samples, args.seed)
+    report["policy_solve_elapsed_seconds"] = policy_seconds
+    report["total_elapsed_seconds"] = time.monotonic() - started
+    serialized = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+        print(f"Wrote {args.output}")
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/artifact_pipeline/analyze_opponent_hand_points.py
+++ b/artifact_pipeline/analyze_opponent_hand_points.py
@@ -489,9 +489,9 @@ def analyze(  # pylint: disable=too-many-locals
             ),
         },
         "recommendation": (
-            "defer a production opponent-hand artifact because its value is constant "
-            "across the user's discard choices; retain suit-normalized binary or "
-            "rank-baseline-plus-residual encoding as feasible presentation-only research"
+            "defer publishing until a position-aware experiment determines whether "
+            "opponent mean, distribution, tail probabilities, or joint outcomes are "
+            "needed; use the compact exact rank model as the first positional input"
         ),
         "elapsed_seconds": time.monotonic() - started,
     }

--- a/artifact_pipeline/test_analyze_opponent_hand_points.py
+++ b/artifact_pipeline/test_analyze_opponent_hand_points.py
@@ -1,0 +1,244 @@
+"""Tests for the issue 75 opponent hand-points analysis."""
+
+import argparse
+import json
+import math
+import random
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from artifact_pipeline.analytical_solver import (
+    get_card_removal_weight,
+    get_hand_combinations_with_weights,
+    score_combination_suit_free,
+)
+from artifact_pipeline.analyze_opponent_hand_points import (
+    CONDITIONED_OPPONENT_DEALS,
+    DEALER,
+    PHYSICAL_SIX_CARD_DEALS,
+    PONE,
+    PolicySubsetAggregate,
+    REPRESENTATIVE_PHYSICAL_DEALS,
+    SampleMoments,
+    _parse_args,
+    _physical_sample_seed,
+    _rank_table_sizes,
+    _sample_rank_policy_keep,
+    _normalized_size_projections,
+    analyze,
+    build_policy_subset_aggregates,
+    canonical_suit_key,
+    conditioned_suitless_expected_values,
+    exact_suitless_table,
+    main,
+    nonnegative_int,
+    physical_deal_key,
+    positive_int,
+    rank_hand_key,
+    sample_suit_aware_hand_points,
+    suit_normalized_six_card_state_count,
+)
+from artifact_pipeline.generate_play_table import DiscardPolicy
+
+
+def first_four_policy():
+    """Return a deterministic policy for every valid six-rank hand."""
+    mapping = {}
+    for hand, _weight in get_hand_combinations_with_weights():
+        for role in (PONE, DEALER):
+            mapping[(role, hand)] = hand[:4]
+    return DiscardPolicy(mapping)
+
+
+class TestOpponentHandPointAnalysis(unittest.TestCase):
+    """Exercise exact, physical, sizing, and command paths."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = first_four_policy()
+        cls.hands = get_hand_combinations_with_weights()
+        cls.aggregates = build_policy_subset_aggregates(cls.policy, cls.hands)
+
+    def test_integer_parsers(self):
+        self.assertEqual(positive_int("2"), 2)
+        self.assertEqual(nonnegative_int("0"), 0)
+        with self.assertRaises(argparse.ArgumentTypeError):
+            positive_int("0")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            nonnegative_int("-1")
+
+    def test_canonical_suit_key_normalizes_global_renaming(self):
+        clubs_diamonds = ((0, 0), (1, 0), (2, 0), (3, 0), (4, 1), (5, 1))
+        hearts_spades = ((0, 2), (1, 2), (2, 2), (3, 2), (4, 3), (5, 3))
+        different_incidence = ((0, 0), (1, 0), (2, 0), (3, 1), (4, 0), (5, 1))
+        self.assertEqual(
+            canonical_suit_key(clubs_diamonds), canonical_suit_key(hearts_spades)
+        )
+        self.assertNotEqual(
+            canonical_suit_key(clubs_diamonds), canonical_suit_key(different_incidence)
+        )
+        with self.assertRaises(ValueError):
+            canonical_suit_key(((0, 0), (0, 0)))
+        with self.assertRaises(ValueError):
+            canonical_suit_key(((13, 0),))
+
+    def test_burnside_state_count(self):
+        self.assertEqual(PHYSICAL_SIX_CARD_DEALS, 20_358_520)
+        self.assertEqual(suit_normalized_six_card_state_count(), 962_988)
+
+    def test_streaming_sample_moments(self):
+        empty = SampleMoments()
+        self.assertEqual(empty.standard_deviation, 0.0)
+        self.assertTrue(math.isinf(empty.standard_error))
+        empty.add(2.0)
+        self.assertEqual(empty.standard_deviation, 0.0)
+        empty.add(4.0)
+        self.assertAlmostEqual(empty.mean, 3.0)
+        self.assertAlmostEqual(empty.standard_error, 1.0)
+
+    def test_conditioned_exact_value_matches_direct_enumeration(self):
+        known = (0, 1, 2, 3, 4, 5)
+        actual = conditioned_suitless_expected_values(known, self.aggregates)
+        direct_totals = {PONE: 0.0, DEALER: 0.0}
+        direct_weight = 0
+        for hand, _weight in self.hands:
+            weight = get_card_removal_weight(known, hand)
+            if not weight:
+                continue
+            direct_weight += weight
+            for role in (PONE, DEALER):
+                kept = self.policy.kept_ranks(role, hand)
+                direct_totals[role] += weight * sum(
+                    (4 - known.count(rank) - hand.count(rank))
+                    * score_combination_suit_free(kept, rank)
+                    for rank in range(13)
+                )
+        self.assertEqual(direct_weight, CONDITIONED_OPPONENT_DEALS)
+        for role in (PONE, DEALER):
+            self.assertAlmostEqual(
+                actual[role], direct_totals[role] / (direct_weight * 40)
+            )
+
+    def test_conditioned_value_rejects_incomplete_aggregates(self):
+        incomplete = dict(self.aggregates)
+        incomplete[()] = PolicySubsetAggregate()
+        with self.assertRaisesRegex(ValueError, "conditioned opponent deal count"):
+            conditioned_suitless_expected_values(
+                (0, 1, 2, 3, 4, 5),
+                incomplete,
+            )
+
+    def test_exact_table_keys_and_limit(self):
+        with patch(
+            "artifact_pipeline.analyze_opponent_hand_points.build_policy_subset_aggregates",
+            return_value=self.aggregates,
+        ):
+            table = exact_suitless_table(self.policy, hand_limit=2)
+        self.assertEqual(len(table), 2)
+        self.assertEqual(next(iter(table)), "A_A_A_A_2_2")
+        self.assertEqual(rank_hand_key((0, 9, 10, 11, 12)), "A_T_J_Q_K")
+
+    def test_rank_policy_suit_selection_and_physical_sampling(self):
+        dealt = ((0, 0), (0, 1), (1, 0), (2, 0), (3, 0), (4, 0))
+        keep = _sample_rank_policy_keep(self.policy, PONE, dealt, random.Random(42))
+        self.assertEqual(len(keep), 4)
+        first_name, known = REPRESENTATIVE_PHYSICAL_DEALS[0]
+        seed = _physical_sample_seed(42, first_name, PONE)
+        first = sample_suit_aware_hand_points(known, PONE, self.policy, 5, seed)
+        second = sample_suit_aware_hand_points(known, PONE, self.policy, 5, seed)
+        self.assertEqual(
+            (first.n, first.mean, first.moment_2), (5, second.mean, second.moment_2)
+        )
+        with self.assertRaisesRegex(ValueError, "six unique"):
+            sample_suit_aware_hand_points(known[:5], PONE, self.policy, 1, seed)
+
+    def test_keys_and_size_projections(self):
+        self.assertEqual(physical_deal_key(((0, 0), (12, 3))), "A0_K3")
+        table = {
+            "A_2_3_4_5_6": {PONE: 4.0, DEALER: 5.0},
+            "8_9_T_J_Q_K": {PONE: 6.0, DEALER: 7.0},
+        }
+        sizes = _rank_table_sizes(table)
+        self.assertGreater(sizes["minified_json_bytes"], 0)
+        self.assertGreater(sizes["gzip_bytes"], 0)
+        self.assertEqual(sizes["packed_float32_value_bytes"], 16)
+        projected = _normalized_size_projections(table, 10)
+        self.assertEqual(projected["packed_float32_value_bytes"], 80)
+        self.assertEqual(projected["quantized_int16_residual_bytes"], 40)
+        self.assertEqual(projected["rank_float32_plus_quantized_residual_bytes"], 56)
+
+    def test_analysis_report_with_and_without_physical_pilot(self):
+        table = {
+            rank_hand_key(sorted(card[0] for card in known)): {
+                PONE: float(index + 4),
+                DEALER: float(index + 5),
+            }
+            for index, (_name, known) in enumerate(REPRESENTATIVE_PHYSICAL_DEALS)
+        }
+        moments = SampleMoments()
+        moments.add(5.0)
+        moments.add(7.0)
+        with patch(
+            "artifact_pipeline.analyze_opponent_hand_points.exact_suitless_table",
+            return_value=table,
+        ), patch(
+            "artifact_pipeline.analyze_opponent_hand_points.sample_suit_aware_hand_points",
+            return_value=moments,
+        ):
+            report = analyze(self.policy, None, 2, 42)
+            without_pilot = analyze(self.policy, 1, 0, 42)
+        one_entry = {next(iter(table)): next(iter(table.values()))}
+        with patch(
+            "artifact_pipeline.analyze_opponent_hand_points.exact_suitless_table",
+            return_value=one_entry,
+        ), patch(
+            "artifact_pipeline.analyze_opponent_hand_points.sample_suit_aware_hand_points",
+            return_value=moments,
+        ):
+            partial_pilot = analyze(self.policy, 1, 2, 42)
+        self.assertFalse(
+            report["discard_invariance"]["opponent_ev_varies_across_user_discards"]
+        )
+        self.assertEqual(report["suit_aware_pilot"]["deal_count"], 6)
+        self.assertEqual(without_pilot["suit_aware_pilot"]["deal_count"], 0)
+        self.assertGreater(partial_pilot["suit_aware_pilot"]["deal_count"], 0)
+        self.assertLess(partial_pilot["suit_aware_pilot"]["deal_count"], 6)
+        self.assertTrue("defer" in report["recommendation"])
+
+    def test_parse_args_and_main_output_paths(self):
+        args = _parse_args(
+            [
+                "--hand-limit=2",
+                "--physical-samples=0",
+                "--seed=7",
+                "--analytical-max-iterations=2",
+                "--full-hand-policy-max-iterations=1",
+            ]
+        )
+        self.assertEqual((args.hand_limit, args.physical_samples, args.seed), (2, 0, 7))
+        context = type("Context", (), {"selected_discards": []})()
+        report = {"recommendation": "defer"}
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "report.json"
+            with patch(
+                "artifact_pipeline.analyze_opponent_hand_points.solve_initial_discard_policy",
+                return_value=context,
+            ), patch(
+                "artifact_pipeline.analyze_opponent_hand_points.selected_discards_to_policy",
+                return_value=self.policy,
+            ), patch(
+                "artifact_pipeline.analyze_opponent_hand_points.analyze",
+                return_value=report,
+            ):
+                self.assertEqual(main(["--output", str(output)]), 0)
+                written = json.loads(output.read_text())
+                self.assertEqual(written["recommendation"], "defer")
+                self.assertGreaterEqual(written["policy_solve_elapsed_seconds"], 0.0)
+                self.assertGreaterEqual(written["total_elapsed_seconds"], 0.0)
+                self.assertEqual(main([]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/expected-opponent-hand-points-spike.md
+++ b/docs/expected-opponent-hand-points-spike.md
@@ -1,0 +1,187 @@
+# Expected Opponent Hand Points Spike
+
+## Recommendation
+
+Defer a production expected-opponent-hand artifact.
+
+Suit normalization makes a suit-aware table feasible to store, particularly in
+a packed representation, but the value cannot change discard recommendations.
+Once the user's full six-card deal is known, the same six cards are unavailable
+for every one of the 15 discard choices. An opponent who cannot see the user's
+selected discard therefore has the same possible deal, discard policy, and
+starter distribution for every row. Adding the opponent expectation subtracts
+the same constant from every candidate and leaves their ordering unchanged.
+
+The estimate may still make a future presentation read more naturally. That is
+a product-display question rather than a discard-analysis improvement, and it
+does not justify the generation and browser costs on its own.
+
+## Model
+
+The objective model used for this spike is:
+
+1. Remove the user's six known physical cards from the deck.
+2. Deal the opponent six cards uniformly without replacement from the 46
+   remaining cards.
+3. Select the opponent's four kept ranks with the existing role-specific
+   analytical `E(h +/- c)` policy: Dealer maximizes hand plus crib value, and
+   Pone maximizes hand minus crib value.
+4. Draw the starter uniformly from the 40 cards remaining after both six-card
+   deals.
+5. Score the opponent's kept hand using ordinary non-crib hand scoring.
+
+Random discards are objective as a baseline but do not represent a rational
+opponent. The legacy static strategy mixes rules of thumb with mathematical
+components and is not suitable as the defining model. The policy-driven model
+is reproducible and consistent with the artifact pipeline's mathematical
+principle.
+
+The analytical policy reached its configured 100 pair iterations and three
+full-hand refinement iterations. It ended in the existing small pair-policy
+cycle and with 183 changed full-hand discards, so the reported values are exact
+conditional expectations for that bounded policy, not a claim of globally
+converged optimal play. The discard-invariance conclusion does not depend on
+which hidden-information opponent policy is chosen.
+
+## Suitless Exact Analysis
+
+The suitless model groups physical cards by rank. There are 18,395 valid
+six-rank multisets after enforcing the four-card limit for each rank. Their
+physical multiplicities sum to all `C(52, 6) = 20,358,520` six-card deals.
+
+For a known rank hand `U`, opponent hand `H`, role policy keep `K(H)`, and
+starter rank `r`, the exact expectation is proportional to:
+
+```text
+sum_H weight(H | U) * sum_r (4 - count_U(r) - count_H(r)) * score(K(H), r)
+```
+
+The denominator is `C(46, 6) * 40`. Inclusion-exclusion aggregates for subsets
+of the six known cards make all 18,395 conditionals practical without a
+quadratic loop over known and opponent hands.
+
+On 2026-07-11, using Python 3.14.4 on arm64 macOS 26.5.1:
+
+- bounded analytical policy construction took 373.6 seconds;
+- all 18,395 exact conditional entries took 3.2 seconds afterward;
+- sampling variance is exactly zero inside the rank model;
+- Dealer expectations ranged from 6.794 to 8.578 points, with a population
+  standard deviation of 0.244 across known rank deals; and
+- Pone expectations ranged from 6.906 to 8.731 points, with a population
+  standard deviation of 0.256 across known rank deals.
+
+This variation is large enough to change the displayed opponent-side number
+between different deals, but it remains constant among the 15 discard choices
+within any one deal.
+
+The full rank table with two JSON numbers per key measured 1,247,728 bytes
+minified and 379,967 bytes with gzip. Its two raw float32 values per key require
+147,160 bytes before an index.
+
+## Suit-Aware Analysis
+
+Cribbage scoring is unchanged by globally renaming the four suits. Canonicalizing
+each physical deal across all 24 suit permutations reduces 20,358,520 physical
+deals to 962,988 equivalence classes. For example, a four-club/two-diamond deal
+is equivalent to the same rank-to-suit incidence expressed as four hearts and
+two spades. A different assignment of ranks to those suits is not necessarily
+equivalent.
+
+The 962,988 count was calculated with the group-action fixed-point average:
+
+```text
+(20,358,520 + 6*450,216 + 3*2,600 + 8*5,512 + 6*0) / 24
+= 962,988
+```
+
+Exact physical enumeration is not practical for a complete table. One known
+deal has `C(46, 6) * 40 = 374,672,760` opponent-deal/starter outcomes before
+evaluating alternative discard candidates. Repeating that for 962,988
+normalized known deals would exceed 360 trillion outcomes.
+
+The physical pilot sampled six representative known deals covering one-suit,
+4-2, 3-3, 2-2-2, paired-rank, and triple-rank patterns. It used 10,000 samples
+per deal and opponent role, for 120,000 samples total, with seed 42. Physical
+cards, flushes, and nobs were scored exactly. Discarded ranks came from the
+analytical policy; when rank-equivalent physical cards could be kept, their
+suits were selected without bias. This tests suit-aware scoring and removal but
+does not claim a fully suit-optimized opponent policy.
+
+The observed score standard deviations were 3.61 to 3.95 points, producing
+standard errors of 0.036 to 0.039 at 10,000 samples. Differences from the
+suitless baseline ranged from -0.014 to +0.071 points. Most were no larger than
+about two pilot standard errors, so the pilot does not establish a reliable
+per-entry suit correction at this sample count.
+
+The pilot ran at about 76,814 samples per second on one process. Using its
+largest observed standard deviation, a complete two-role normalized table is
+projected to require:
+
+| Target per-entry SE | Samples per entry | Total samples | Single-process time |
+| --- | ---: | ---: | ---: |
+| 0.04 | 9,729 | 18.74 billion | 2.8 days |
+| 0.02 | 38,915 | 74.95 billion | 11.3 days |
+| 0.01 | 155,660 | 299.80 billion | 45.2 days |
+
+These are sampling-only projections. A fully suit-aware discard policy would
+add work and should be measured separately before any production commitment.
+
+## Artifact Implications
+
+For 962,988 normalized keys and two role values:
+
+| Representation | Estimated size | Notes |
+| --- | ---: | --- |
+| Minified JSON | 70.9 MB | Projected from representative physical keys and values |
+| Gzip JSON | 21.6 MB | Rough projection using the rank table's compression ratio |
+| Packed float32 values | 7.7 MB | Excludes a key-to-index implementation |
+| Quantized int16 suit residuals | 3.9 MB | Requires a separately defined precision bound |
+| Rank float32 baseline plus int16 residuals | 4.0 MB | Excludes indexing and transport framing |
+
+Suit normalization therefore makes producer-side storage manageable. A single
+JSON object remains unattractive for a browser because transfer size understates
+its parsed JavaScript-object memory. A packed or rank-baseline-plus-residual
+format is a plausible future direction if a presentation experiment establishes
+user value, but it would require a deliberate browser contract, precision gate,
+and consumer implementation.
+
+## Acceptance Criteria Assessment
+
+- A feasible model is documented for both exact suitless and sampled suit-aware
+  analysis.
+- Runtime, variance, noise floor, and candidate artifact sizes are measured or
+  explicitly projected from measured data.
+- Exact enumeration is practical for the rank model but not for a complete
+  physical-card table; Monte Carlo or a more advanced exact aggregation would
+  be required for suit-aware values.
+- Opponent hand points change no discard rankings within a known six-card deal.
+- Production should be deferred; normalized packed encodings remain future
+  research for presentation only.
+- All expensive opponent-hand analysis stays in the Python producer. No
+  browser-side simulation is proposed.
+
+## Reproducing the Analysis
+
+Run the complete analysis from the repository root:
+
+```sh
+python artifact_pipeline/analyze_opponent_hand_points.py \
+  --physical-samples=10000 \
+  --seed=42 \
+  --output=opponent_hand_points_analysis.json
+```
+
+For a bounded smoke run, reduce the analytical policy and output surface:
+
+```sh
+python artifact_pipeline/analyze_opponent_hand_points.py \
+  --analytical-max-iterations=2 \
+  --full-hand-policy-max-iterations=1 \
+  --hand-limit=4 \
+  --physical-samples=0 \
+  --output=opponent_hand_points_analysis.smoke.json
+```
+
+The JSON output includes timing, state counts, exact role summaries, physical
+pilot moments, runtime projections, and representation-size estimates. It is a
+research report, not a published client artifact.

--- a/docs/expected-opponent-hand-points-spike.md
+++ b/docs/expected-opponent-hand-points-spike.md
@@ -2,19 +2,33 @@
 
 ## Recommendation
 
-Defer a production expected-opponent-hand artifact.
+Do not publish an expected-opponent-hand artifact solely for the current
+position-unaware `E(h +/- c)` ranking. Preserve this work as a technically
+practical precursor to board-position-aware discard analysis, where the likely
+strength of the opponent's hand can affect whether the player should favor
+offense, defense, or score volatility.
 
-Suit normalization makes a suit-aware table feasible to store, particularly in
-a packed representation, but the value cannot change discard recommendations.
 Once the user's full six-card deal is known, the same six cards are unavailable
 for every one of the 15 discard choices. An opponent who cannot see the user's
 selected discard therefore has the same possible deal, discard policy, and
-starter distribution for every row. Adding the opponent expectation subtracts
-the same constant from every candidate and leaves their ordering unchanged.
+starter distribution for every row. Adding the opponent mean directly to the
+current linear `E(h +/- c)` objective subtracts the same constant from every
+candidate and leaves their ordering unchanged.
 
-The estimate may still make a future presentation read more naturally. That is
-a product-display question rather than a discard-analysis improvement, and it
-does not justify the generation and browser costs on its own.
+That does not make the estimate strategically irrelevant. A position-aware
+objective is nonlinear: the value of a discard can depend on whether either
+player is likely to cross a board threshold, which player counts first, and
+whether a high-variance offensive line or a lower-variance defensive line is
+preferable. The opponent expectation can supply context for those choices even
+though it is constant across the current hand's discard rows.
+
+The next step should be a vertical positional-play experiment using the compact
+exact rank model. Before freezing a production contract, that experiment should
+determine whether the opponent's mean is sufficient or whether score
+distributions, tail probabilities, or joint player/opponent outcomes are needed.
+Only then should the project decide whether suit-aware refinement materially
+improves positional decisions enough to justify its additional generation and
+browser costs.
 
 ## Model
 
@@ -41,7 +55,9 @@ full-hand refinement iterations. It ended in the existing small pair-policy
 cycle and with 183 changed full-hand discards, so the reported values are exact
 conditional expectations for that bounded policy, not a claim of globally
 converged optimal play. The discard-invariance conclusion does not depend on
-which hidden-information opponent policy is chosen.
+which hidden-information opponent policy is chosen. Its implication is limited
+to adding the value as a linear term in the current position-unaware objective;
+it does not rule out the value as context for a nonlinear board-position policy.
 
 ## Suitless Exact Analysis
 
@@ -87,7 +103,24 @@ is equivalent to the same rank-to-suit incidence expressed as four hearts and
 two spades. A different assignment of ranks to those suits is not necessarily
 equivalent.
 
-The 962,988 count was calculated with the group-action fixed-point average:
+There are 24 possible global suit renamings. Applying one renaming to every card
+in a deal is the "action," and a deal is a "fixed point" of a renaming when the
+renamed cards form exactly the same unordered deal. Most deals move to another
+representation, but some symmetric deals stay unchanged under particular suit
+swaps or cycles.
+
+Burnside's lemma says that the number of distinct normalized deals is the
+average number of deals left unchanged by each of the 24 renamings. This avoids
+incorrectly dividing by 24: symmetric deals have fewer than 24 distinct
+representations and would otherwise be undercounted. The fixed-deal counts are:
+
+- the identity renaming fixes all 20,358,520 deals;
+- each of the 6 single suit swaps fixes 450,216 deals;
+- each of the 3 pairs of simultaneous suit swaps fixes 2,600 deals;
+- each of the 8 three-suit cycles fixes 5,512 deals; and
+- each of the 6 four-suit cycles fixes no six-card deal.
+
+Averaging those fixed-deal counts gives:
 
 ```text
 (20,358,520 + 6*450,216 + 3*2,600 + 8*5,512 + 6*0) / 24
@@ -141,9 +174,14 @@ For 962,988 normalized keys and two role values:
 Suit normalization therefore makes producer-side storage manageable. A single
 JSON object remains unattractive for a browser because transfer size understates
 its parsed JavaScript-object memory. A packed or rank-baseline-plus-residual
-format is a plausible future direction if a presentation experiment establishes
-user value, but it would require a deliberate browser contract, precision gate,
-and consumer implementation.
+format is a plausible future direction if positional-play experiments establish
+that suit corrections affect decisions. It would require a deliberate browser
+contract, precision gate, and consumer implementation.
+
+The exact rank-only result is much cheaper: about 0.38 MB with gzip and 3.2
+seconds to calculate after constructing the existing analytical policy. It is
+therefore the appropriate starting point for a position-aware experiment rather
+than a reason to abandon opponent-hand modeling.
 
 ## Acceptance Criteria Assessment
 
@@ -154,9 +192,13 @@ and consumer implementation.
 - Exact enumeration is practical for the rank model but not for a complete
   physical-card table; Monte Carlo or a more advanced exact aggregation would
   be required for suit-aware values.
-- Opponent hand points change no discard rankings within a known six-card deal.
-- Production should be deferred; normalized packed encodings remain future
-  research for presentation only.
+- Opponent hand points change no rankings when added linearly to the current
+  position-unaware objective, but they can inform future nonlinear positional
+  strategy.
+- Publishing is deferred in this spike pending a position-aware experiment that
+  determines whether a mean, distribution, tail probabilities, or joint outcome
+  model is the correct production contract. The exact rank model is the
+  recommended first input to that experiment.
 - All expensive opponent-hand analysis stays in the Python producer. No
   browser-side simulation is proposed.
 

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -135,12 +135,17 @@ history.
 
 An expected opponent hand value conditioned on the user's full six-card deal is
 constant across that user's discard candidates, because every candidate removes
-the same six cards from the opponent-deal and starter populations. Treat it as
-presentation research rather than a discard-ranking input. For suit-aware
-analysis, normalize only by global suit permutations that preserve each rank's
-suit incidence. The resulting 962,988 six-card states are manageable for packed
-producer storage but require explicit precision, indexing, transfer, and parsed
-memory analysis before becoming a browser contract.
+the same six cards from the opponent-deal and starter populations. It cannot
+change rankings as a linear term in the current position-unaware objective, but
+it can inform nonlinear board-position strategy such as offensive, defensive,
+or variance-seeking play. Use the compact exact rank model for initial
+positional experiments and establish whether the consumer needs a mean,
+distribution, tail probabilities, or joint outcomes before defining an
+artifact. For suit-aware analysis, normalize only by global suit permutations
+that preserve each rank's suit incidence. The resulting 962,988 six-card states
+are manageable for packed producer storage but require explicit precision,
+indexing, transfer, and parsed-memory analysis before becoming a browser
+contract.
 
 Coverage must not decrease as a result of code changes. New simulator behavior
 must include focused tests, especially for cribbage scoring, discard selection,

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -133,6 +133,15 @@ including absolute Pone and Dealer point-type components and the keyed player's
 paired delta. Keep policy views limited to the acting player's cards and public
 history.
 
+An expected opponent hand value conditioned on the user's full six-card deal is
+constant across that user's discard candidates, because every candidate removes
+the same six cards from the opponent-deal and starter populations. Treat it as
+presentation research rather than a discard-ranking input. For suit-aware
+analysis, normalize only by global suit permutations that preserve each rank's
+suit incidence. The resulting 962,988 six-card states are manageable for packed
+producer storage but require explicit precision, indexing, transfer, and parsed
+memory analysis before becoming a browser contract.
+
 Coverage must not decrease as a result of code changes. New simulator behavior
 must include focused tests, especially for cribbage scoring, discard selection,
 play selection, game-state transitions, and command-line options.


### PR DESCRIPTION
## Summary

- add a reproducible exact suitless and sampled suit-aware opponent hand-points analysis
- document runtime, variance, normalized state counts, and candidate artifact sizes
- prove that opponent hand EV is constant across all 15 discard choices from one known six-card deal
- distinguish current linear discard invariance from future nonlinear board-position value, and recommend an exact-rank positional experiment before defining a production contract

## Key findings

- The exact suitless model has 18,395 valid six-rank states and zero sampling variance.
- Global suit normalization reduces 20,358,520 physical six-card deals to 962,988 equivalence classes while preserving rank-to-suit incidence.
- A normalized two-role table is projected at about 70.9 MB minified JSON, 21.6 MB gzip JSON, 7.7 MB packed float32, or 4.0 MB for a rank baseline plus int16 suit residuals, excluding indexing details.
- At the measured physical-score variance and throughput, a complete normalized table is projected to take about 2.8 days at per-entry SE 0.04, 11.3 days at SE 0.02, or 45.2 days at SE 0.01 on one process.
- The opponent expectation cannot change rankings when added linearly to the current position-unaware objective because the same six user cards are removed for every discard choice and the opponent cannot observe the selected discard.
- It can still affect future position-aware strategy by indicating whether offensive, defensive, or variance-seeking play is appropriate near board thresholds; that work may need a score distribution or tail probabilities rather than only the mean.

## Acceptance criteria

- [x] Document at least one feasible modeling approach: exact suitless conditioning and a suit-aware physical-card pilot are both documented.
- [x] Estimate runtime, variance/noise floor, and artifact size: the checked-in report records measured and projected values.
- [x] Identify exact-enumeration practicality: exact rank enumeration is practical; full physical enumeration exceeds 374 million outcomes per known deal before discard alternatives.
- [x] Assess ranking impact: the report proves the opponent term adds the same constant to all 15 candidates in the current linear objective and explains its distinct value as context for nonlinear positional strategy.
- [x] Recommend an outcome: defer publishing until a position-aware experiment establishes whether the contract needs the opponent mean, a distribution, tail probabilities, or joint outcomes; use the compact exact rank model first.
- [x] Keep browser-side simulation out of scope: the new command is producer-side research only and no release workflow or client contract changes.

## Validation

- `coverage run` / `coverage xml` / `coverage report`: 221 tests passed, 5 skipped.
- `coverage run -m unittest discover artifact_pipeline` plus `coverage run --append scripts/run_slow_analytical_tests.py`: 216 fast and 5 slow tests passed; `artifact_pipeline/*` coverage is 100%.
- `mypy simulate_cribbage_games.py artifact_pipeline`: passed.
- `pylint --persistent=n artifact_pipeline`: passed at 10.00/10.
- `pylint --persistent=n --disable=all --enable=duplicate-code simulate_cribbage_games.py`: passed.
- `flake8`: passed.
- `npm run spellcheck`: passed.
- Black, codespell, cspell, mypy, flake8, coverage, artifact pylint, and legacy duplicate-code pre-commit/pre-push hooks: passed.
- Full and bounded opponent-analysis commands: passed.
- Isolated `python simulate_cribbage_games.py --game-count 10` smoke run with an initialized tally shelf: passed with plausible hand, crib, and play output.

The ordinary `pylint simulate_cribbage_games.py` command still reports the repository's existing immutable-legacy findings at 9.70/10; this PR does not change that file. The sandbox also prevented pylint from writing its user cache, without affecting analysis results.

## Durable learnings

The linear discard-invariance rule, nonlinear positional-value boundary, suit normalization, and browser-contract warning are captured in `AGENTS.md` and `skills/SKILLS.md` as required by repository policy.

Closes #75

_PR description prepared by OpenAI Codex._
