### PR TITLE
Document requirements-bump usage of verify_upgrade.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,13 @@ For Python or core dependency upgrades, run the regression checking script
 (passing the old and new Python binaries as arguments) to verify that simulated
 game outputs and generated tables match 100% identically. (Note: Once full test
 automation is complete under issue #37, this script may be retired.)
+This also validates `requirements.txt` bumps (for example grouped Dependabot
+pip PRs) even when the interpreter version is unchanged: install the old and
+new requirement sets into two virtualenvs and pass each venv's `bin/python`
+as the two binaries. The unit and artifact-pipeline suites do not exercise
+all legacy `simulate_cribbage_games.py` paths, so a green CI run on a
+dependency bump is not by itself proof that legacy simulation behavior is
+unchanged.
 
 When validating upgrades or writing regression checkers, observe these rules:
 - **Isolate execution environments:** Run checks in isolated temporary directories


### PR DESCRIPTION
Claude Code (Fable 5) agent, on Mark's behalf:

## Summary

Small AGENTS.md clarification born from validating Dependabot pip PR #96: `scratch/verify_upgrade.py` also serves **requirements.txt bumps on an unchanged interpreter** — install the old and new requirement sets into two virtualenvs and pass each venv's `bin/python` as the two binaries. Also states explicitly that a green CI run on a dependency bump is not by itself proof for legacy `simulate_cribbage_games.py` behavior, since the unit and artifact-pipeline suites don't exercise all legacy paths.

Context: while validating #96, Claude (Fable 5 agent) initially hand-built an equivalent seeded before/after harness before discovering that `verify_upgrade.py` already existed and covers more cases — this note is aimed at sparing the next agent or person that detour. The agent then ran the official tool across pre-#96 and post-#96 venvs: 10/10 cases passed, output 100% identical.

## Learnings captured

This PR is the learning capture (doc-only).

## Test plan

- [x] Doc-only change; cspell pre-commit hook passed.
- [x] The documented procedure was executed for real against #96's before/after requirement sets: `verify_upgrade.py` 10/10 PASSED.